### PR TITLE
Updating app descriptor elements to match 50.2

### DIFF
--- a/docs/building/application-descriptor-files/elements/android.md
+++ b/docs/building/application-descriptor-files/elements/android.md
@@ -133,7 +133,7 @@ Available: 33.1.1.698
 
 If `true` then `adt` will use the legacy build process to create an APK. The current process uses Android build tools and Gradle to create AAB and APK outputs. Setting this value to `true` will utilise the legacy Java build process for packaging an APK. It will not affect the AAB process. 
 
-The default is `false`, which will use the modern Gradle build process.
+The default is `false`, which will use the modern Gradle build process. Note that setting this to `true` may cause problems for new applications needing some Android features or using ANEs.
 
 #### Example
 
@@ -143,4 +143,121 @@ The default is `false`, which will use the modern Gradle build process.
 	<BuildLegacyAPK>true</BuildLegacyAPK>
 </android>
 ```
+
+
+
+### `addAirToAppID`
+
+(optional)
+
+Available: 50.0.0.1
+
+This flag provides a way to remove the default `air.` prefix that the AIR Developer Tool normally adds to an Android application ID. By default this is `true` which matches the earlier Adobe behaviour,
+but if an application already has a fully-qualified reverse domain name type identifier, then this could be set to `false` in order to generate an application without the prefix in the Android package ID.
+
+
+### `buildArchitectures`
+
+(optional)
+
+Available: 50.0.0.1
+
+This is a utility setting to instruct the AIR Developer Tool to only use certain architectures in the final APK/AAB file. It overrides whatever might have been provided on the command line instruction to
+ADT, so this can be used to change the outputs of a build that was created via Adobe Animate or other IDEs that haven't been updated to provide the appropriate options.
+
+The default is `armv7,armv8,x86,x64` which means an Android App Bundle would include all of the supported platforms. To remove support for 32-bit devices, this could be updated to `armv8,x64`.
+Or to remove support for Intel-architecture devices, this could be set to `armv7,armv8`.
+
+
+### `createAppBundle`
+
+(optional)
+
+Available: 50.0.0.1
+
+This is another utility, to force the AIR Developer Tool to create an Android App Bundle file even if the command line or IDE had requested an APK file.
+Note that the output filename will not be updated so if the request was to generate a file "output.apk" then this will be honoured even though this .apk file is actually an AAB.
+
+### `uncompressedExtensions`
+
+(optional)
+
+Available: 50.0.0.1
+
+This utility setting can be used to specify a set of file extensions that should not be compressed when stored in the APK or AAB file. Normally these are compressed formats and so most files
+are added using the 'deflate' option, but using this setting the developer can prevent certain files from being compressed, which allows them to be accessed via some of the Android asset APIs.
+
+#### Example
+
+```xml
+<android>
+	<uncompressedExtensions>jpg,gif,png</uncompressedExtensions>
+</android>
+```
+
+
+### `newFontRenderingFromAPI`
+
+(optional)
+
+Available: 33.1.1.779
+
+Due to changes in the native Android font rendering code, the AIR runtime will switch to render text fields using the Android Java APIs when a device is running Android S or later.
+This option gives some finer control over this switch. By default the value is `31` which is the API level for Android S, but if a lower value is used, the new Java-based APIs will be used
+from that API level and above.
+
+To always use the Java-based font rendering, the value should be set to zero. To never use it (which is not advisable unless the text is always within the Latin character set) it can be set to 9999 or similar.
+
+
+### `webViewAllowFileAccess`
+
+(optional)
+
+Available: 33.1.1.698
+
+Allows an Android webview control to access local files via `WebSettings.setAllowFileAccess(true)`. Default is `false`.
+
+
+### `preventDeviceModelAccess`
+
+(optional)
+
+Available: 33.1.1.795
+
+This is a security/privacy setting to prevent the runtime from accessing the device model (`android.os.Build.MODEL`). Default is `false` and should be set to `true` if this `MODEL` property access should not be made.
+
+
+### `disableSensorAccess`
+
+(optional)
+
+Available: 50.1.1.1
+
+This goes beyond the above privacy setting, to completely disable the access of sensor hardware APIs including input mechanisms, orientation sensors, and telephony services.
+Note that this value can be overriden by adding a file into the application's app storage folder, see release notes for further details.
+
+The default value is `false`, and should be set to `true` if required by privacy controls.
+
+
+### `runtimeInBackgroundThread`
+
+(optional)
+
+Available: 50.2.1.1
+
+If `true`, this causes the AIR runtime to be launched in a separate, background thread rather than in the main Android UI thread. This should help prevent ANE issues,
+but may require some updates in other Android Java code (i.e. from AIR Native Extensions that may need some of their code to run on the UI thread). Default is `false`.
+
+
+### `storageAccessFrameworkFromAPI`
+
+(optional)
+
+Available: 50.2.1.1
+
+This changes how the ActionScript `File.browse...` methods work, and the file-based permission handling, due to changes in the Android file system security.
+The default value here is `30` which equates to Android R (11.0). From this version and beyond, the `File` browse methods will use the Storage Access Framework and
+launch the standard system intents to browse for opening and saving files or to select a folder. Permissions are then automatically granted and persisted for the selected files/folder.
+
+To switch to this mechanism from earlier versions of Android, the value can be changed to the appropriate API level, or to ensure this doesn't change behaviour yet, the value can be set much higher.
 

--- a/docs/building/application-descriptor-files/elements/application.md
+++ b/docs/building/application-descriptor-files/elements/application.md
@@ -411,6 +411,31 @@ For example:
 ```
 
 
+### `allowMultipleInstances`
+
+<span class="badge badge--success">optional</span>
+
+Available: 50.0.0.1
+
+This setting can be used to allow multiple instances of a desktop AIR application to be launched as separate processes, rather than the standard behaviour of new invocations just resulting in an `InvokeEvent` being sent to a running instance of the application.
+Note that on macOS, opening a new instance of an application must be done via `open -n`.
+
+Default value is `false`.
+
+
+### `stacktraces`
+
+<span class="badge badge--success">optional</span>
+
+Available: 50.1.1.1
+
+Controls the availability and verbosity of stack traces available to the application. The setting may be `none`, `standard` or `verbose`.
+Before this flag, the availability of stack traces depended on the SWF version number, and the verbosity on whether or not the SWF file included debug information (file name and line number details).
+`none` means that no stack traces are generated when an error is raised. `standard` would cause a stack trace to be created but without file and line information.
+`verbose` would then include the file and line details, assuming these are available within the SWF file.
+
+
+
 ## Other elements
 
 The `application` element can also contain other elements that are described further in other sections:

--- a/docs/building/application-descriptor-files/elements/iPhone.md
+++ b/docs/building/application-descriptor-files/elements/iPhone.md
@@ -101,6 +101,21 @@ See [Device names](#device-names) for valid values to use for the `excludeDevice
 </iPhone> 
 ```
 
+### `disableCustomKeyboard`
+
+Available: 33.1.1.686
+
+If this value is set to `true` it will prevent the use of third party keyboards from being used for text input. This should be set if there are privacy concerns about sensitive text entry.
+
+
+
+### `excludeDefaultUsageDescriptions`
+
+Available: 33.1.1.758
+
+This setting can be used to prevent the AIR Developer Tool from generating automatic text fields ("Required by Apple") for the usage descriptions required by iOS for camera/photo and location access. 
+If this is set to `true` then the developer should add their own values into the `InfoAdditions` section of the app descriptor file.
+
 
 ## Device names
 

--- a/docs/building/application-descriptor-files/elements/initialWindow.md
+++ b/docs/building/application-descriptor-files/elements/initialWindow.md
@@ -27,7 +27,9 @@ The `initialWindow` element provides information about the first window that wil
     <aspectRatio>landscape</aspectRatio> 
     <autoOrients>true</autoOrients> 
     <fullScreen>false</fullScreen> 
-    <renderMode>direct</renderMode> 
+    <renderMode>direct</renderMode>
+    <requestedDisplayResolution>standard</requestedDisplayResolution>
+	<allowLowQuality>false</allowLowQuality>
 </initialWindow>
 ```
 
@@ -329,6 +331,21 @@ On devices with standard-resolution screens, the stage dimensions match the scre
     <requestedDisplayResolution>high</requestedDisplayResolution> 
 </initialWindow>
 ```
+
+
+
+
+
+### `allowLowQuality`
+
+<span class="badge badge--success">optional</span>
+
+Available: 33.1.1.795
+
+Specifies whether the application can be set into the "low" or "medium" values for the Stage quality.
+
+On desktop/multi-window versions of AIR, the `Stage.quality` value is normally pegged to `high` or `best`; without this value being set to `true`, the runtime will ignore requests to reduce the quality to `medium` or `low`.
+
 
 
 

--- a/docs/building/application-descriptor-files/elements/windows.md
+++ b/docs/building/application-descriptor-files/elements/windows.md
@@ -9,9 +9,33 @@ The `windows` element provides platform-specific settings for applications runni
 
 ### `UseWebView2`
 
+(optional)
+
+Available: 33.1.1.620
+
 Requests the runtime to try creating a Microsoft Edge "WebView2" component, rather than the IE-based "WebBrowser" control, when a native `StageWebView` element is created.
 
 This component will need to be present on an end user's computer before this works: please see Microsoft's information on [downloading the WebView2 runtime](https://developer.microsoft.com/en-us/microsoft-edge/webview2/#download-section)
+
+
+### `maxD3D`
+
+(optional)
+
+Available: 33.1.1.929
+
+Sets a limit on the Direct3D APIs used by the AIR runtime on Windows. If this value is set, it should be an integer value and AIR will not use a Direct3D version higher than this value.
+Currently this means that to force the runtime to use Direct3D 9, it can be set to `9`, and to prevent the runtime from using Direct3D, it can be set to `0`. The default for new SWFs is Direct3D 11.
+
+
+### `clipboardFullHTML`
+
+(optional)
+
+Available: 50.0.0.1
+
+This setting can be used to retrieve the full Windows clipboard entry for HTML strings. Default behaviour is `false` which will only provide the body text of the HTML contents.
+To ensure the full clipboard contents are retrieved for HTML strings, set the value to `true`.
 
 
 


### PR DESCRIPTION
Hi
Some updates to the documentation here, many from 33.1 but adding all the latest changes in the app descriptor elements up to the new 50.2 release.