### PR TITLE
Correct Java version

### DIFF
--- a/docs/basics/install/linux.mdx
+++ b/docs/basics/install/linux.mdx
@@ -73,4 +73,4 @@ adt -version
 
 ### Java
 
-You must make sure you have version of Java 8 installed and that your `JAVA_HOME` environment variable is set to the JDK’s folder.
+You must make sure you have version of Java 11 installed and that your `JAVA_HOME` environment variable is set to the JDK’s folder.


### PR DESCRIPTION
Top of article specifies Java 11.  Bottom specifies Java 8.  

Windows and Mac versions are consistently Java 11, so Java 8 looks to be an error.