### PR TITLE
Specify JDK requirement

### DIFF
--- a/docs/basics/install/linux.mdx
+++ b/docs/basics/install/linux.mdx
@@ -12,9 +12,7 @@ To install and run AIR your development environment must meet these minimum requ
 
 - Linux
 - 1.3GB free disk space (for the AIR SDK and does not include other tools)
-- A version of Java 11
-
-
+- A version of Java 11 JDK
 
 
 ## Download the SDK

--- a/docs/basics/install/macos.mdx
+++ b/docs/basics/install/macos.mdx
@@ -16,7 +16,7 @@ To install and run AIR your development environment must meet these minimum requ
 
 - macOS
 - 1.3GB free disk space (for the AIR SDK and does not include other tools)
-- A version of Java 11
+- A version of Java 11 JDK
 
 
 ## Install the SDK 

--- a/docs/basics/install/windows.mdx
+++ b/docs/basics/install/windows.mdx
@@ -16,10 +16,10 @@ To install and run AIR your development environment must meet these minimum requ
 
 - Windows 7 or later
 - 1.3GB free disk space (for the AIR SDK and does not include other tools)
-- A version of Java 11
+- A version of Java 11 JDK
+
 
 ## Install the SDK
-
 
 You have two options to install the AIR SDK. The recommended method is to use the AIR SDK Manager. The manager will inform you of available updates and minimise the download required for each update.
 


### PR DESCRIPTION
Whether the JDK or just the JRE is required, is ambiguous.  If JDK is required (and I could be mistaken with that assumption), specifying it is helpful.

The JDK is referenced at the bottom of each article, so it does appear to be what's needed.