### PR TITLE
AS3 documentation updates for June 2025.

### DIFF
--- a/static/reference/actionscript/3.0/all-index-A.html
+++ b/static/reference/actionscript/3.0/all-index-A.html
@@ -214,6 +214,7 @@ The Accelerometer class dispatches AccelerometerEvent objects when acceleration 
 </tr>
 <tr>
 <td width="20"></td><td>
+
      The current accessibility options for this display object.</td>
 </tr>
 <tr>
@@ -569,6 +570,7 @@ ceiling of 0xFF.</td>
 </tr>
 <tr>
 <td width="20"></td><td>
+
  Dispatched when a display object is added to the display list.</td>
 </tr>
 <tr>
@@ -584,7 +586,9 @@ ceiling of 0xFF.</td>
 </tr>
 <tr>
 <td width="20"></td><td>
+
  Dispatched when a display object is added to the on stage display list, 
+
  either directly or through the addition of a sub tree in which the display object is contained.</td>
 </tr>
 <tr>
@@ -1126,6 +1130,7 @@ ceiling of 0xFF.</td>
 </tr>
 <tr>
 <td width="20"></td><td>
+
      Indicates the alpha transparency value of the object specified.</td>
 </tr>
 <tr>
@@ -2661,6 +2666,18 @@ The AutoCapitalize class defines constants for the
 	AVM1Movie is a simple class that represents AVM1 movie clips, which use ActionScript 1.0 or 2.0.</td>
 </tr>
 <tr>
+<td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('avm2/intrinsics/iteration/class-list.html');" href="avm2/intrinsics/iteration/package-detail.html">avm2.intrinsics.iteration</a> &mdash; Package</td>
+</tr>
+<tr>
+<td width="20"></td><td>The amv2.intrinsics.iteration package includes the low-level/intrinsic iteration APIs that are part of the ASC2 compiler.</td>
+</tr>
+<tr>
+<td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('avm2/intrinsics/memory/class-list.html');" href="avm2/intrinsics/memory/package-detail.html">avm2.intrinsics.memory</a> &mdash; Package</td>
+</tr>
+<tr>
+<td width="20"></td><td>The amv2.intrinsics.memory package includes the low-level/intrinsic memory access APIs that are part of the ASC2 compiler.</td>
+</tr>
+<tr>
 <td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('flash/geom/class-list.html');" href="flash/geom/Orientation3D.html#AXIS_ANGLE">AXIS_ANGLE</a> &mdash; Constant static property in class flash.geom.<a onclick="javascript:loadClassListFrame('flash/geom/class-list.html');" href="flash/geom/Orientation3D.html">Orientation3D</a></td>
 </tr>
 <tr>
@@ -2677,10 +2694,10 @@ The AutoCapitalize class defines constants for the
 <p></p>
 <div class="feedbackLink">
 <center>
-<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Thu Feb 27 2025, 6:06 AM GMT) : A Index">Submit Feedback</a>
+<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Mon Jun 30 2025, 11:00 AM GMT+01:00) : A Index">Submit Feedback</a>
 </center>
 </div>
-<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Thu Feb 27 2025, 6:06 AM GMT<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
+<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Mon Jun 30 2025, 11:00 AM GMT+01:00<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
 </div>
 </body>
-</html><!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Thu Feb 27 2025, 6:06 AM GMT <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->
+</html><!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Mon Jun 30 2025, 11:00 AM GMT+01:00 <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->

--- a/static/reference/actionscript/3.0/all-index-C.html
+++ b/static/reference/actionscript/3.0/all-index-C.html
@@ -58,7 +58,9 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("CÂ
 </tr>
 <tr>
 <td width="20"></td><td>
+
      If set to <code>true</code>, Flash runtimes cache an internal bitmap representation of the
+
      display object.</td>
 </tr>
 <tr>
@@ -66,7 +68,9 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("CÂ
 </tr>
 <tr>
 <td width="20"></td><td>
+
      If non-null, this Matrix object defines how a display object is rendered when 
+
      <code>cacheAsBitmap</code> is set to <code>true</code>.</td>
 </tr>
 <tr>
@@ -467,6 +471,14 @@ on mobile devices, but it is not supported on desktop operating systems or AIR f
      Specifies case-insensitive sorting for the Array class sorting methods.</td>
 </tr>
 <tr>
+<td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('avm2/intrinsics/memory/class-list.html');" href="avm2/intrinsics/memory/package.html#casi32()">casi32</a>(addr, expectedVal, newVal) &mdash; Package function in <a onclick="loadClassListFrame('avm2/intrinsics/memory/class-list.html')" href="avm2/intrinsics/memory/package.html">avm2.intrinsics.memory</a></td>
+</tr>
+<tr>
+<td width="20"></td><td>
+
+     A compare-and-swap operation for domainMemory.</td>
+</tr>
+<tr>
 <td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('./class-list.html');" href="./Math.html#ceil()">ceil</a>(val:<a href="Number.html" onclick="javascript:loadClassListFrame('./class-list.html');">Number</a>) &mdash; Static method in class <a onclick="javascript:loadClassListFrame('class-list.html');" href="Math.html">Math</a></td>
 </tr>
 <tr>
@@ -636,8 +648,11 @@ The CFFHinting class defines values for cff hinting in the FontDescription class
 </tr>
 <tr>
 <td width="20"></td><td>
+
     Dispatched each time the sending worker calls this MessageChannel 
+
     object's <code>send()</code> method, indicating that a new message object 
+
     is available in the MessageChannel instance's queue.</td>
 </tr>
 <tr>
@@ -659,7 +674,9 @@ The CFFHinting class defines values for cff hinting in the FontDescription class
 </tr>
 <tr>
 <td width="20"></td><td>
+
     Dispatched when the value of the message channel's <code>state</code> 
+
     property changes.</td>
 </tr>
 <tr>
@@ -2188,7 +2205,9 @@ The ClipboardFormats class defines constants for the names of the standard data 
 </tr>
 <tr>
 <td width="20"></td><td>
+
         Instructs the current MessageChannel to close once all messages have 
+
 		been received.</td>
 </tr>
 <tr>
@@ -2226,7 +2245,9 @@ The ClipboardFormats class defines constants for the names of the standard data 
 </tr>
 <tr>
 <td width="20"></td><td>
+
 		This state indicates that the message channel has been closed and 
+
         doesn't have any more messages to deliver.</td>
 </tr>
 <tr>
@@ -2265,8 +2286,11 @@ The ClipboardFormats class defines constants for the names of the standard data 
 </tr>
 <tr>
 <td width="20"></td><td>
+
 		This state indicates that the message channel has been instructed to 
+
         close and is in the process of delivering the remaining messages on 
+
         the channel.</td>
 </tr>
 <tr>
@@ -4634,6 +4658,7 @@ The ConvolutionFilter class applies a matrix convolution filter effect.</td>
 </tr>
 <tr>
 <td width="20"></td><td>
+
  The CubeTexture class represents a cube texture uploaded to a rendering context.</td>
 </tr>
 <tr>
@@ -4946,10 +4971,10 @@ The ConvolutionFilter class applies a matrix convolution filter effect.</td>
 <p></p>
 <div class="feedbackLink">
 <center>
-<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Thu Feb 27 2025, 6:06 AM GMT) : C Index">Submit Feedback</a>
+<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Mon Jun 30 2025, 11:00 AM GMT+01:00) : C Index">Submit Feedback</a>
 </center>
 </div>
-<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Thu Feb 27 2025, 6:06 AM GMT<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
+<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Mon Jun 30 2025, 11:00 AM GMT+01:00<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
 </div>
 </body>
-</html><!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Thu Feb 27 2025, 6:06 AM GMT <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->
+</html><!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Mon Jun 30 2025, 11:00 AM GMT+01:00 <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->

--- a/static/reference/actionscript/3.0/all-index-E.html
+++ b/static/reference/actionscript/3.0/all-index-E.html
@@ -539,7 +539,9 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("EÂ
 </tr>
 <tr>
 <td width="20"></td><td>
+
  [broadcast event] Dispatched when the playhead is entering a new 
+
  frame.</td>
 </tr>
 <tr>
@@ -738,6 +740,36 @@ Erases the background based on the alpha value of the display object.</td>
 <tr>
 <td width="20"></td><td>
 	 Dispatched when a request for a rendering context fails.</td>
+</tr>
+<tr>
+<td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('flash/display3D/textures/class-list.html');" href="flash/display3D/textures/CubeTexture.html#event:error">error</a> &mdash; Event in class flash.display3D.textures.<a onclick="javascript:loadClassListFrame('flash/display3D/textures/class-list.html');" href="flash/display3D/textures/CubeTexture.html">CubeTexture</a></td>
+</tr>
+<tr>
+<td width="20"></td><td>
+
+ Dispatched by the CubeTexture object when an asynchronous texture upload
+
+ operation fails in some way.</td>
+</tr>
+<tr>
+<td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('flash/display3D/textures/class-list.html');" href="flash/display3D/textures/RectangleTexture.html#event:error">error</a> &mdash; Event in class flash.display3D.textures.<a onclick="javascript:loadClassListFrame('flash/display3D/textures/class-list.html');" href="flash/display3D/textures/RectangleTexture.html">RectangleTexture</a></td>
+</tr>
+<tr>
+<td width="20"></td><td>
+
+ Dispatched by the RectangleTexture object when an asynchronous texture upload
+
+ operation fails in some way.</td>
+</tr>
+<tr>
+<td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('flash/display3D/textures/class-list.html');" href="flash/display3D/textures/Texture.html#event:error">error</a> &mdash; Event in class flash.display3D.textures.<a onclick="javascript:loadClassListFrame('flash/display3D/textures/class-list.html');" href="flash/display3D/textures/Texture.html">Texture</a></td>
+</tr>
+<tr>
+<td width="20"></td><td>
+
+ Dispatched by the Texture object when an asynchronous texture upload
+
+ operation fails in some way.</td>
 </tr>
 <tr>
 <td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('flash/events/class-list.html');" href="flash/events/AsyncErrorEvent.html#error">error</a> &mdash; Property in class flash.events.<a onclick="javascript:loadClassListFrame('flash/events/class-list.html');" href="flash/events/AsyncErrorEvent.html">AsyncErrorEvent</a></td>
@@ -1245,6 +1277,7 @@ the original aspect ratio.</td>
 </tr>
 <tr>
 <td width="20"></td><td>
+
  [broadcast event] Dispatched when the playhead is exiting the current frame.</td>
 </tr>
 <tr>
@@ -1410,10 +1443,10 @@ the original aspect ratio.</td>
 <p></p>
 <div class="feedbackLink">
 <center>
-<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Thu Feb 27 2025, 6:06 AM GMT) : E Index">Submit Feedback</a>
+<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Mon Jun 30 2025, 11:00 AM GMT+01:00) : E Index">Submit Feedback</a>
 </center>
 </div>
-<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Thu Feb 27 2025, 6:06 AM GMT<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
+<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Mon Jun 30 2025, 11:00 AM GMT+01:00<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
 </div>
 </body>
-</html><!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Thu Feb 27 2025, 6:06 AM GMT <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->
+</html><!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Mon Jun 30 2025, 11:00 AM GMT+01:00 <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->

--- a/static/reference/actionscript/3.0/all-index-H.html
+++ b/static/reference/actionscript/3.0/all-index-H.html
@@ -214,6 +214,7 @@ Adjusts the color of each pixel based on the darkness of the display object.</td
 </tr>
 <tr>
 <td width="20"></td><td> 
+
         Specifies whether a provided string can be displayed using the currently assigned font.</td>
 </tr>
 <tr>
@@ -254,6 +255,14 @@ Adjusts the color of each pixel based on the darkness of the display object.</td
 <td width="20"></td><td>
     Specifies whether the system supports multichannel audio of a specific
     type.</td>
+</tr>
+<tr>
+<td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('avm2/intrinsics/iteration/class-list.html');" href="avm2/intrinsics/iteration/package.html#hasnext()">hasnext</a>(obj, idx) &mdash; Package function in <a onclick="loadClassListFrame('avm2/intrinsics/iteration/class-list.html')" href="avm2/intrinsics/iteration/package.html">avm2.intrinsics.iteration</a></td>
+</tr>
+<tr>
+<td width="20"></td><td>
+
+	 Determine whether the given object has any more properties.</td>
 </tr>
 <tr>
 <td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('./class-list.html');" href="./Object.html#hasOwnProperty()">hasOwnProperty</a>(name:<a href="String.html" onclick="javascript:loadClassListFrame('./class-list.html');">String</a>) &mdash; Method in class <a onclick="javascript:loadClassListFrame('class-list.html');" href="Object.html">Object</a></td>
@@ -437,6 +446,7 @@ Adjusts the color of each pixel based on the darkness of the display object.</td
 </tr>
 <tr>
 <td width="20"></td><td>
+
      Indicates the height of the display object, in pixels.</td>
 </tr>
 <tr>
@@ -481,6 +491,7 @@ Adjusts the color of each pixel based on the darkness of the display object.</td
 </tr>
 <tr>
 <td width="20"></td><td>
+
      Indicates the height of the display object, in pixels.</td>
 </tr>
 <tr>
@@ -488,6 +499,7 @@ Adjusts the color of each pixel based on the darkness of the display object.</td
 </tr>
 <tr>
 <td width="20"></td><td>
+
 	The height of the rectangle, in pixels.</td>
 </tr>
 <tr>
@@ -642,6 +654,7 @@ Adjusts the color of each pixel based on the darkness of the display object.</td
 </tr>
 <tr>
 <td width="20"></td><td>
+
 	     Navigates to the previous page in the browsing history.</td>
 </tr>
 <tr>
@@ -655,6 +668,7 @@ Adjusts the color of each pixel based on the darkness of the display object.</td
 </tr>
 <tr>
 <td width="20"></td><td>
+
 	     Navigates to the next page in the browsing history.</td>
 </tr>
 <tr>
@@ -697,7 +711,9 @@ Adjusts the color of each pixel based on the darkness of the display object.</td
 </tr>
 <tr>
 <td width="20"></td><td>
+
      Evaluates the bounding box of the display object to see if it overlaps or intersects with the
+
      bounding box of the <code>obj</code> display object.</td>
 </tr>
 <tr>
@@ -705,7 +721,9 @@ Adjusts the color of each pixel based on the darkness of the display object.</td
 </tr>
 <tr>
 <td width="20"></td><td>
+
      Evaluates the display object to see if it overlaps or intersects with the
+
      point specified by the <code>x</code> and <code>y</code> parameters.</td>
 </tr>
 <tr>
@@ -952,7 +970,9 @@ Adjusts the color of each pixel based on the darkness of the display object.</td
 </tr>
 <tr>
 <td width="20"></td><td>
+
  Dispatched if a call to the load() method attempts to access data over HTTP,
+
  and Adobe AIR is able to detect and return the status code for the request.</td>
 </tr>
 <tr>
@@ -960,7 +980,9 @@ Adjusts the color of each pixel based on the darkness of the display object.</td
 </tr>
 <tr>
 <td width="20"></td><td>
+
  Dispatched if a call to the <code>URLStream.load()</code> method attempts to access data over HTTP 
+
  and Adobe AIR is able to detect and return the status code for the request.</td>
 </tr>
 <tr>
@@ -991,7 +1013,9 @@ Adjusts the color of each pixel based on the darkness of the display object.</td
 </tr>
 <tr>
 <td width="20"></td><td>
+
  Dispatched if a call to URLLoader.load()
+
  attempts to access data over HTTP.</td>
 </tr>
 <tr>
@@ -999,8 +1023,11 @@ Adjusts the color of each pixel based on the darkness of the display object.</td
 </tr>
 <tr>
 <td width="20"></td><td>
+
  Dispatched if a call to <code>URLStream.load()</code> 
+
  attempts to access data over HTTP, and <span platform="actionscript">Flash Player or </span> Adobe AIR
+
  is able to detect and return the status code for the request.</td>
 </tr>
 <tr>
@@ -1036,11 +1063,10 @@ status code.</td>
 <p></p>
 <div class="feedbackLink">
 <center>
-<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Wed Sep 28 2022, 6:12 PM GMT+01:00) : H Index">Submit Feedback</a>
+<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Mon Jun 30 2025, 11:00 AM GMT+01:00) : H Index">Submit Feedback</a>
 </center>
 </div>
-<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Wed Sep 28 2022, 6:12 PM GMT+01:00<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
+<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Mon Jun 30 2025, 11:00 AM GMT+01:00<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
 </div>
 </body>
-</html>
-<!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Wed Sep 28 2022, 6:12 PM GMT+01:00 <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->
+</html><!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Mon Jun 30 2025, 11:00 AM GMT+01:00 <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->

--- a/static/reference/actionscript/3.0/all-index-L.html
+++ b/static/reference/actionscript/3.0/all-index-L.html
@@ -686,6 +686,46 @@ Specifies that the Stage is aligned on the left.</td>
  	 Constant for H.264 level 5.1.</td>
 </tr>
 <tr>
+<td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('avm2/intrinsics/memory/class-list.html');" href="avm2/intrinsics/memory/package.html#lf32()">lf32</a>(addr) &mdash; Package function in <a onclick="loadClassListFrame('avm2/intrinsics/memory/class-list.html')" href="avm2/intrinsics/memory/package.html">avm2.intrinsics.memory</a></td>
+</tr>
+<tr>
+<td width="20"></td><td>
+
+	 Loads a 32-bit floating point value from the given <code>addr</code> in domain memory.</td>
+</tr>
+<tr>
+<td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('avm2/intrinsics/memory/class-list.html');" href="avm2/intrinsics/memory/package.html#lf64()">lf64</a>(addr) &mdash; Package function in <a onclick="loadClassListFrame('avm2/intrinsics/memory/class-list.html')" href="avm2/intrinsics/memory/package.html">avm2.intrinsics.memory</a></td>
+</tr>
+<tr>
+<td width="20"></td><td>
+
+	 Loads a 64-bit floating point value from the given <code>addr</code> in domain memory.</td>
+</tr>
+<tr>
+<td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('avm2/intrinsics/memory/class-list.html');" href="avm2/intrinsics/memory/package.html#li16()">li16</a>(addr) &mdash; Package function in <a onclick="loadClassListFrame('avm2/intrinsics/memory/class-list.html')" href="avm2/intrinsics/memory/package.html">avm2.intrinsics.memory</a></td>
+</tr>
+<tr>
+<td width="20"></td><td>
+
+	 Loads a 16-bit integer value from the given <code>addr</code> in domain memory.</td>
+</tr>
+<tr>
+<td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('avm2/intrinsics/memory/class-list.html');" href="avm2/intrinsics/memory/package.html#li32()">li32</a>(addr) &mdash; Package function in <a onclick="loadClassListFrame('avm2/intrinsics/memory/class-list.html')" href="avm2/intrinsics/memory/package.html">avm2.intrinsics.memory</a></td>
+</tr>
+<tr>
+<td width="20"></td><td>
+
+	 Loads a 32-bit integer value from the given <code>addr</code> in domain memory.</td>
+</tr>
+<tr>
+<td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('avm2/intrinsics/memory/class-list.html');" href="avm2/intrinsics/memory/package.html#li8()">li8</a>(addr) &mdash; Package function in <a onclick="loadClassListFrame('avm2/intrinsics/memory/class-list.html')" href="avm2/intrinsics/memory/package.html">avm2.intrinsics.memory</a></td>
+</tr>
+<tr>
+<td width="20"></td><td>
+
+	 Loads an 8-bit integer value from the given <code>addr</code> in domain memory.</td>
+</tr>
+<tr>
 <td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('air/system/class-list.html');" href="air/system/License.html">License</a> &mdash; Class in package <a onclick="javascript:loadClassListFrame('air/system/class-list.html');" href="air/system/package-detail.html">air.system</a></td>
 </tr>
 <tr>
@@ -1168,7 +1208,9 @@ parameter in the <code>Graphics.lineStyle()</code> method.</td>
 </tr>
 <tr>
 <td width="20"></td><td>
+
      Returns a LoaderInfo object containing information about loading the file
+
      to which this display object belongs.</td>
 </tr>
 <tr>
@@ -1291,7 +1333,9 @@ parameter in the <code>Graphics.lineStyle()</code> method.</td>
 </tr>
 <tr>
 <td width="20"></td><td>
+
      Converts a three-dimensional point of the three-dimensional display 
+
      object's (local) coordinates to a two-dimensional point in the Stage (global) coordinates.</td>
 </tr>
 <tr>
@@ -1490,7 +1534,9 @@ parameter in the <code>Graphics.lineStyle()</code> method.</td>
 </tr>
 <tr>
 <td width="20"></td><td>
+
      Converts the <code>point</code> object from the display object's (local) coordinates to the
+
      Stage (global) coordinates.</td>
 </tr>
 <tr>
@@ -1890,10 +1936,10 @@ frame (does not appear for a single-frame SWF file).</td>
 <p></p>
 <div class="feedbackLink">
 <center>
-<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Thu Feb 27 2025, 6:06 AM GMT) : L Index">Submit Feedback</a>
+<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Mon Jun 30 2025, 11:00 AM GMT+01:00) : L Index">Submit Feedback</a>
 </center>
 </div>
-<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Thu Feb 27 2025, 6:06 AM GMT<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
+<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Mon Jun 30 2025, 11:00 AM GMT+01:00<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
 </div>
 </body>
-</html><!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Thu Feb 27 2025, 6:06 AM GMT <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->
+</html><!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Mon Jun 30 2025, 11:00 AM GMT+01:00 <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->

--- a/static/reference/actionscript/3.0/all-index-M.html
+++ b/static/reference/actionscript/3.0/all-index-M.html
@@ -170,6 +170,7 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("MÂ
 </tr>
 <tr>
 <td width="20"></td><td>
+
      The calling display object is masked by the specified <code>mask</code> object.</td>
 </tr>
 <tr>
@@ -774,7 +775,9 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("MÂ
 </tr>
 <tr>
 <td width="20"></td><td>
+
         Indicates whether the MessageChannel has one or more messages from 
+
         the sending worker in its internal message queue.</td>
 </tr>
 <tr>
@@ -782,7 +785,9 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("MÂ
 </tr>
 <tr>
 <td width="20"></td><td>
+
  	The MessageChannel class provides a mechanism for a worker to communicate 
+
     with another worker.</td>
 </tr>
 <tr>
@@ -790,7 +795,9 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("MÂ
 </tr>
 <tr>
 <td width="20"></td><td>
+
   	This class defines constants that represent the possible values for the 
+
     MessageChannel class's <code>state</code> property.</td>
 </tr>
 <tr>
@@ -798,7 +805,9 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("MÂ
 </tr>
 <tr>
 <td width="20"></td><td>
+
      Obtains the meta data object of the DisplayObject instance if meta data was stored alongside the
+
      the instance of this DisplayObject in the SWF file through a PlaceObject4 tag.</td>
 </tr>
 <tr>
@@ -814,6 +823,14 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("MÂ
 <tr>
 <td width="20"></td><td>
      Controls the HTTP form submission method.</td>
+</tr>
+<tr>
+<td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('avm2/intrinsics/memory/class-list.html');" href="avm2/intrinsics/memory/package.html#mfence()">mfence</a>() &mdash; Package function in <a onclick="loadClassListFrame('avm2/intrinsics/memory/class-list.html')" href="avm2/intrinsics/memory/package.html">avm2.intrinsics.memory</a></td>
+</tr>
+<tr>
+<td width="20"></td><td>
+
+     A complete memory barrier for domainMemory (for both load and store instructions).</td>
 </tr>
 <tr>
 <td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('flash/media/class-list.html');" href="flash/media/Microphone.html">Microphone</a> &mdash; Final class in package <a onclick="javascript:loadClassListFrame('flash/media/class-list.html');" href="flash/media/package-detail.html">flash.media</a></td>
@@ -1505,6 +1522,7 @@ of the Mouse class.</td>
 </tr>
 <tr>
 <td width="20"></td><td>
+
      Indicates the x coordinate of the mouse or user input device position, in pixels.</td>
 </tr>
 <tr>
@@ -1512,6 +1530,7 @@ of the Mouse class.</td>
 </tr>
 <tr>
 <td width="20"></td><td>
+
      Indicates the y coordinate of the mouse or user input device position, in pixels.</td>
 </tr>
 <tr>
@@ -1880,11 +1899,10 @@ resulting in darker colors.</td>
 <p></p>
 <div class="feedbackLink">
 <center>
-<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Thu Mar 21 2024, 10:06 AM GMT) : M Index">Submit Feedback</a>
+<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Mon Jun 30 2025, 11:00 AM GMT+01:00) : M Index">Submit Feedback</a>
 </center>
 </div>
-<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Thu Mar 21 2024, 10:06 AM GMT<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
+<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Mon Jun 30 2025, 11:00 AM GMT+01:00<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
 </div>
 </body>
-</html>
-<!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Thu Mar 21 2024, 10:06 AM GMT <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->
+</html><!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Mon Jun 30 2025, 11:00 AM GMT+01:00 <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->

--- a/static/reference/actionscript/3.0/all-index-N.html
+++ b/static/reference/actionscript/3.0/all-index-N.html
@@ -96,6 +96,7 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("NÂ
 </tr>
 <tr>
 <td width="20"></td><td>
+
      Indicates the instance name of the DisplayObject.</td>
 </tr>
 <tr>
@@ -499,6 +500,7 @@ The NativeDragActions class defines string constants for the names of the drag-a
 </tr>
 <tr>
 <td width="20"></td><td>
+
      The NativeMenu class contains methods and properties for defining native menus.</td>
 </tr>
 <tr>
@@ -506,6 +508,7 @@ The NativeDragActions class defines string constants for the names of the drag-a
 </tr>
 <tr>
 <td width="20"></td><td>
+
              Creates a new NativeMenu object.</td>
 </tr>
 <tr>
@@ -1231,6 +1234,14 @@ related to a NetStream object's underlying RTMFP Peer-to-Peer and IP Multicast s
 	 or the validity of the line is <code>TextLineValidity.STATIC</code>.</td>
 </tr>
 <tr>
+<td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('avm2/intrinsics/iteration/class-list.html');" href="avm2/intrinsics/iteration/package.html#nextname()">nextname</a>(obj, idx) &mdash; Package function in <a onclick="loadClassListFrame('avm2/intrinsics/iteration/class-list.html')" href="avm2/intrinsics/iteration/package.html">avm2.intrinsics.iteration</a></td>
+</tr>
+<tr>
+<td width="20"></td><td>
+
+	 Get the name of the next property.</td>
+</tr>
+<tr>
 <td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('flash/utils/class-list.html');" href="flash/utils/Proxy.html#nextName()">nextName</a>(index:<a href="int.html" onclick="javascript:loadClassListFrame('./class-list.html');">int</a>) &mdash; Method in class flash.utils.<a onclick="javascript:loadClassListFrame('flash/utils/class-list.html');" href="flash/utils/Proxy.html">Proxy</a></td>
 </tr>
 <tr>
@@ -1263,6 +1274,14 @@ related to a NetStream object's underlying RTMFP Peer-to-Peer and IP Multicast s
 <tr>
 <td width="20"></td><td>
 	 An XMLNode value that references the next sibling in the parent node's child list.</td>
+</tr>
+<tr>
+<td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('avm2/intrinsics/iteration/class-list.html');" href="avm2/intrinsics/iteration/package.html#nextvalue()">nextvalue</a>(obj, idx) &mdash; Package function in <a onclick="loadClassListFrame('avm2/intrinsics/iteration/class-list.html')" href="avm2/intrinsics/iteration/package.html">avm2.intrinsics.iteration</a></td>
+</tr>
+<tr>
+<td width="20"></td><td>
+
+	 Get the value of the next property.</td>
 </tr>
 <tr>
 <td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('flash/utils/class-list.html');" href="flash/utils/Proxy.html#nextValue()">nextValue</a>(index:<a href="int.html" onclick="javascript:loadClassListFrame('./class-list.html');">int</a>) &mdash; Method in class flash.utils.<a onclick="javascript:loadClassListFrame('flash/utils/class-list.html');" href="flash/utils/Proxy.html">Proxy</a></td>
@@ -1970,6 +1989,7 @@ of the player window changes.</td>
 </tr>
 <tr>
 <td width="20"></td><td>
+
 			 The number of NativeMenuItem objects in this menu.</td>
 </tr>
 <tr>
@@ -2149,11 +2169,10 @@ of the player window changes.</td>
 <p></p>
 <div class="feedbackLink">
 <center>
-<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Thu Mar 21 2024, 10:06 AM GMT) : N Index">Submit Feedback</a>
+<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Mon Jun 30 2025, 11:00 AM GMT+01:00) : N Index">Submit Feedback</a>
 </center>
 </div>
-<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Thu Mar 21 2024, 10:06 AM GMT<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
+<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Mon Jun 30 2025, 11:00 AM GMT+01:00<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
 </div>
 </body>
-</html>
-<!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Thu Mar 21 2024, 10:06 AM GMT <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->
+</html><!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Mon Jun 30 2025, 11:00 AM GMT+01:00 <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->

--- a/static/reference/actionscript/3.0/all-index-S.html
+++ b/static/reference/actionscript/3.0/all-index-S.html
@@ -167,6 +167,7 @@ Lets the user with Shockmachine installed save a SWF file.</td>
 </tr>
 <tr>
 <td width="20"></td><td>
+
      The current scaling grid that is in effect.</td>
 </tr>
 <tr>
@@ -195,6 +196,7 @@ Lets the user with Shockmachine installed save a SWF file.</td>
 </tr>
 <tr>
 <td width="20"></td><td>
+
      Indicates the horizontal scale (percentage) of the object as applied from the registration point.</td>
 </tr>
 <tr>
@@ -216,6 +218,7 @@ Lets the user with Shockmachine installed save a SWF file.</td>
 </tr>
 <tr>
 <td width="20"></td><td>
+
      Indicates the vertical scale (percentage) of an object as applied from the registration point of the object.</td>
 </tr>
 <tr>
@@ -237,6 +240,7 @@ Lets the user with Shockmachine installed save a SWF file.</td>
 </tr>
 <tr>
 <td width="20"></td><td>
+
      Indicates the depth scale (percentage) of an object as applied from the registration point of the object.</td>
 </tr>
 <tr>
@@ -439,6 +443,7 @@ The SystemTrayIcon object dispatches events of type ScreenMouseEvent in response
 </tr>
 <tr>
 <td width="20"></td><td>
+
      The scroll rectangle bounds of the display object.</td>
 </tr>
 <tr>
@@ -1007,7 +1012,9 @@ security error.</td>
 </tr>
 <tr>
 <td width="20"></td><td>
+
 		Sends an object from the sending worker, adding it to the message 
+
         queue for the receiving worker.</td>
 </tr>
 <tr>
@@ -2082,6 +2089,22 @@ security error.</td>
          Specifies which vertex data components correspond to a single vertex shader program input.</td>
 </tr>
 <tr>
+<td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('avm2/intrinsics/memory/class-list.html');" href="avm2/intrinsics/memory/package.html#sf32()">sf32</a>(value, addr) &mdash; Package function in <a onclick="loadClassListFrame('avm2/intrinsics/memory/class-list.html')" href="avm2/intrinsics/memory/package.html">avm2.intrinsics.memory</a></td>
+</tr>
+<tr>
+<td width="20"></td><td>
+
+	 Stores a 32-bit floating point value into the given <code>addr</code> in domain memory.</td>
+</tr>
+<tr>
+<td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('avm2/intrinsics/memory/class-list.html');" href="avm2/intrinsics/memory/package.html#sf64()">sf64</a>(value, addr) &mdash; Package function in <a onclick="loadClassListFrame('avm2/intrinsics/memory/class-list.html')" href="avm2/intrinsics/memory/package.html">avm2.intrinsics.memory</a></td>
+</tr>
+<tr>
+<td width="20"></td><td>
+
+	 Stores a 64-bit floating point value into the given <code>addr</code> in domain memory.</td>
+</tr>
+<tr>
 <td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('air/security/class-list.html');" href="air/security/Digest.html#SHA1">SHA1</a> &mdash; Constant static property in class air.security.<a onclick="javascript:loadClassListFrame('air/security/class-list.html');" href="air/security/Digest.html">Digest</a></td>
 </tr>
 <tr>
@@ -2466,6 +2489,30 @@ maintaining the original aspect ratio of the application.</td>
 <tr>
 <td width="20"></td><td>
      Displays the Security Settings panel in Flash Player.</td>
+</tr>
+<tr>
+<td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('avm2/intrinsics/memory/class-list.html');" href="avm2/intrinsics/memory/package.html#si16()">si16</a>(value, addr) &mdash; Package function in <a onclick="loadClassListFrame('avm2/intrinsics/memory/class-list.html')" href="avm2/intrinsics/memory/package.html">avm2.intrinsics.memory</a></td>
+</tr>
+<tr>
+<td width="20"></td><td>
+
+	 Stores a 16-bit integer value into the given <code>addr</code> in domain memory.</td>
+</tr>
+<tr>
+<td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('avm2/intrinsics/memory/class-list.html');" href="avm2/intrinsics/memory/package.html#si32()">si32</a>(value, addr) &mdash; Package function in <a onclick="loadClassListFrame('avm2/intrinsics/memory/class-list.html')" href="avm2/intrinsics/memory/package.html">avm2.intrinsics.memory</a></td>
+</tr>
+<tr>
+<td width="20"></td><td>
+
+	 Stores a 32-bit integer value into the given <code>addr</code> in domain memory.</td>
+</tr>
+<tr>
+<td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('avm2/intrinsics/memory/class-list.html');" href="avm2/intrinsics/memory/package.html#si8()">si8</a>(value, addr) &mdash; Package function in <a onclick="loadClassListFrame('avm2/intrinsics/memory/class-list.html')" href="avm2/intrinsics/memory/package.html">avm2.intrinsics.memory</a></td>
+</tr>
+<tr>
+<td width="20"></td><td>
+
+	 Stores an 8-bit integer value into the given <code>addr</code> in domain memory.</td>
 </tr>
 <tr>
 <td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('flash/security/class-list.html');" href="flash/security/X509Certificate.html#signatureAlgorithmOID">signatureAlgorithmOID</a> &mdash; Property in class flash.security.<a onclick="javascript:loadClassListFrame('flash/security/class-list.html');" href="flash/security/X509Certificate.html">X509Certificate</a></td>
@@ -3624,6 +3671,7 @@ in the <code>beginGradientFill()</code> and <code>lineGradientStyle()</code> met
 </tr>
 <tr>
 <td width="20"></td><td>
+
      The Stage of the display object.</td>
 </tr>
 <tr>
@@ -4298,7 +4346,9 @@ The StageScaleMode class provides values for the <code>Stage.scaleMode</code> pr
 </tr>
 <tr>
 <td width="20"></td><td>
+
         Indicates the current state of the MessageChannel object (open, 
+
 		closing, or closed).</td>
 </tr>
 <tr>
@@ -6141,6 +6191,30 @@ color, applying a floor of 0.</td>
     Switches from playing one stream to another stream, typically with streams of the same content.</td>
 </tr>
 <tr>
+<td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('avm2/intrinsics/memory/class-list.html');" href="avm2/intrinsics/memory/package.html#sxi1()">sxi1</a>(value) &mdash; Package function in <a onclick="loadClassListFrame('avm2/intrinsics/memory/class-list.html')" href="avm2/intrinsics/memory/package.html">avm2.intrinsics.memory</a></td>
+</tr>
+<tr>
+<td width="20"></td><td>
+
+	 Sign-extends a 1-bit integer value to a 32-bit integer value.</td>
+</tr>
+<tr>
+<td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('avm2/intrinsics/memory/class-list.html');" href="avm2/intrinsics/memory/package.html#sxi16()">sxi16</a>(value) &mdash; Package function in <a onclick="loadClassListFrame('avm2/intrinsics/memory/class-list.html')" href="avm2/intrinsics/memory/package.html">avm2.intrinsics.memory</a></td>
+</tr>
+<tr>
+<td width="20"></td><td>
+
+	 Sign-extends a 16-bit integer value to a 32-bit integer value.</td>
+</tr>
+<tr>
+<td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('avm2/intrinsics/memory/class-list.html');" href="avm2/intrinsics/memory/package.html#sxi8()">sxi8</a>(value) &mdash; Package function in <a onclick="loadClassListFrame('avm2/intrinsics/memory/class-list.html')" href="avm2/intrinsics/memory/package.html">avm2.intrinsics.memory</a></td>
+</tr>
+<tr>
+<td width="20"></td><td>
+
+	 Sign-extends an 8-bit integer value to a 32-bit integer value.</td>
+</tr>
+<tr>
 <td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('flash/net/class-list.html');" href="flash/net/SharedObject.html#event:sync">sync</a> &mdash; Event in class flash.net.<a onclick="javascript:loadClassListFrame('flash/net/class-list.html');" href="flash/net/SharedObject.html">SharedObject</a></td>
 </tr>
 <tr>
@@ -6349,10 +6423,10 @@ color, applying a floor of 0.</td>
 <p></p>
 <div class="feedbackLink">
 <center>
-<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Thu Feb 27 2025, 6:06 AM GMT) : S Index">Submit Feedback</a>
+<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Mon Jun 30 2025, 11:00 AM GMT+01:00) : S Index">Submit Feedback</a>
 </center>
 </div>
-<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Thu Feb 27 2025, 6:06 AM GMT<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
+<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Mon Jun 30 2025, 11:00 AM GMT+01:00<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
 </div>
 </body>
-</html><!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Thu Feb 27 2025, 6:06 AM GMT <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->
+</html><!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Mon Jun 30 2025, 11:00 AM GMT+01:00 <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->

--- a/static/reference/actionscript/3.0/all-index-T.html
+++ b/static/reference/actionscript/3.0/all-index-T.html
@@ -853,6 +853,7 @@ The TextRotation class is an enumeration of constant values used with the follow
 </tr>
 <tr>
 <td width="20"></td><td>
+
  The Texture class represents a 2-dimensional texture uploaded to a rendering context.</td>
 </tr>
 <tr>
@@ -861,6 +862,36 @@ The TextRotation class is an enumeration of constant values used with the follow
 <tr>
 <td width="20"></td><td>
  The TextureBase class is the base class for Context3D texture objects.</td>
+</tr>
+<tr>
+<td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('flash/display3D/textures/class-list.html');" href="flash/display3D/textures/CubeTexture.html#event:textureReady">textureReady</a> &mdash; Event in class flash.display3D.textures.<a onclick="javascript:loadClassListFrame('flash/display3D/textures/class-list.html');" href="flash/display3D/textures/CubeTexture.html">CubeTexture</a></td>
+</tr>
+<tr>
+<td width="20"></td><td>
+
+ Dispatched by the CubeTexture object when an asynchronous texture upload
+
+ operation has completed successfully, and the texture can then be used.</td>
+</tr>
+<tr>
+<td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('flash/display3D/textures/class-list.html');" href="flash/display3D/textures/RectangleTexture.html#event:textureReady">textureReady</a> &mdash; Event in class flash.display3D.textures.<a onclick="javascript:loadClassListFrame('flash/display3D/textures/class-list.html');" href="flash/display3D/textures/RectangleTexture.html">RectangleTexture</a></td>
+</tr>
+<tr>
+<td width="20"></td><td>
+
+ Dispatched by the RectangleTexture object when an asynchronous texture upload
+
+ operation has completed successfully, and the texture can then be used.</td>
+</tr>
+<tr>
+<td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('flash/display3D/textures/class-list.html');" href="flash/display3D/textures/Texture.html#event:textureReady">textureReady</a> &mdash; Event in class flash.display3D.textures.<a onclick="javascript:loadClassListFrame('flash/display3D/textures/class-list.html');" href="flash/display3D/textures/Texture.html">Texture</a></td>
+</tr>
+<tr>
+<td width="20"></td><td>
+
+ Dispatched by the Texture object when an asynchronous texture upload
+
+ operation has completed successfully, and the texture can then be used.</td>
 </tr>
 <tr>
 <td colspan="2" class="idxrow"><a onclick="javascript:loadClassListFrame('flash/events/class-list.html');" href="flash/events/Event.html#TEXTURE_READY">TEXTURE_READY</a> &mdash; Constant static property in class flash.events.<a onclick="javascript:loadClassListFrame('flash/events/class-list.html');" href="flash/events/Event.html">Event</a></td>
@@ -2630,6 +2661,7 @@ Specifies that the Stage is aligned in the top-right corner.</td>
 </tr>
 <tr>
 <td width="20"></td><td>
+
     An object with properties pertaining to a display object's matrix, color transform, and pixel bounds.</td>
 </tr>
 <tr>
@@ -2973,10 +3005,10 @@ of the ElementFormat class.</td>
 <p></p>
 <div class="feedbackLink">
 <center>
-<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Thu Feb 27 2025, 6:06 AM GMT) : T Index">Submit Feedback</a>
+<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Mon Jun 30 2025, 11:00 AM GMT+01:00) : T Index">Submit Feedback</a>
 </center>
 </div>
-<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Thu Feb 27 2025, 6:06 AM GMT<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
+<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Mon Jun 30 2025, 11:00 AM GMT+01:00<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
 </div>
 </body>
-</html><!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Thu Feb 27 2025, 6:06 AM GMT <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->
+</html><!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Mon Jun 30 2025, 11:00 AM GMT+01:00 <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->

--- a/static/reference/actionscript/3.0/avm2/intrinsics/iteration/class-list.html
+++ b/static/reference/actionscript/3.0/avm2/intrinsics/iteration/class-list.html
@@ -1,0 +1,33 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!-- saved from url=(0014)about:internet -->
+<html>
+<head>
+<META http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>avm2.intrinsics.iteration - ActionScript&nbsp;3.0&nbsp;Language&nbsp;Reference</title>
+<base target="classFrame">
+<link rel="stylesheet" href="../../../style.css" type="text/css" media="screen">
+<link rel="stylesheet" href="../../../print.css" type="text/css" media="print">
+</head>
+<body class="classFrameContent">
+<h3>
+<a style="color:black" target="classFrame" href="package-detail.html">Package avm2.intrinsics.iteration</a>
+</h3>
+<table cellspacing="0" cellpadding="0">
+<tr>
+<td><a style="color:black" href="package.html#methodSummary"><b>Functions</b></a></td>
+</tr>
+<tr>
+<td><a href="package.html#hasnext()">hasnext()</a></td>
+</tr>
+<tr>
+<td><a href="package.html#nextname()">nextname()</a></td>
+</tr>
+<tr>
+<td><a href="package.html#nextvalue()">nextvalue()</a></td>
+</tr>
+<tr>
+<td width="10px">&nbsp;</td>
+</tr>
+</table>
+</body>
+</html><!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Mon Jun 30 2025, 11:00 AM GMT+01:00 <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->

--- a/static/reference/actionscript/3.0/avm2/intrinsics/iteration/package-detail.html
+++ b/static/reference/actionscript/3.0/avm2/intrinsics/iteration/package-detail.html
@@ -1,0 +1,66 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!-- saved from url=(0014)about:internet -->
+<html>
+<head>
+<META http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<link rel="stylesheet" href="../../../style.css" type="text/css" media="screen">
+<link rel="stylesheet" href="../../../print.css" type="text/css" media="print">
+<title>avm2.intrinsics.iteration Summary (ActionScript 3.0)</title>
+</head>
+<body>
+<script type="text/javascript" language="javascript" src="../../../asdoc.js"></script><script type="text/javascript" language="javascript" src="../../../cookies.js"></script><script type="text/javascript" language="javascript">
+<!--
+				asdocTitle = 'avm2.intrinsics.iteration Package - ActionScript 3.0 Language Reference';
+				var baseRef = '../../../';
+				window.onload = configPage;
+			--></script>
+<table style="display:none" id="titleTable" cellspacing="0" cellpadding="0" class="titleTable">
+<tr>
+<td align="left" class="titleTableTitle">ActionScript 3.0 Language Reference</td><td align="right" class="titleTableTopNav"><a onclick="loadClassListFrame('../../../all-classes.html')" href="../../../package-summary.html">All&nbsp;Packages</a>&nbsp;|&nbsp;<a onclick="loadClassListFrame('../../../all-classes.html')" href="../../../class-summary.html">All&nbsp;Classes</a>&nbsp;|&nbsp;<a href="../../../language-elements.html">Language&nbsp;Elements</a>&nbsp;| <a onclick="loadClassListFrame('../../../index-list.html')" href="../../../all-index-Symbols.html">Index</a>&nbsp;|&nbsp;<a href="../../../appendices.html">Appendices</a>&nbsp;|&nbsp;<a href="../../../conventions.html">Conventions</a>&nbsp;|&nbsp;<a href="../../../index.html?avm2/intrinsics/iteration/package-detail.html&amp;avm2/intrinsics/iteration/class-list.html" id="framesLink1">Frames</a><a onclick="parent.location=document.location" href="" style="display:none" id="noFramesLink1">No&nbsp;Frames</a></td><td rowspan="3" align="right" class="titleTableLogo"><img alt="Adobe Logo" title="Adobe Logo" class="logoImage" src="../../../images/logo.jpg"></td>
+</tr>
+<tr class="titleTableRow2">
+<td align="left" id="subTitle" class="titleTableSubTitle">Package&nbsp;avm2.intrinsics.iteration</td><td align="right" id="subNav" class="titleTableSubNav"><a href="package.html#methodSummary">Functions</a></td>
+</tr>
+<tr class="titleTableRow3">
+<td colspan="2">&nbsp;</td>
+</tr>
+</table>
+<script type="text/javascript" language="javascript">
+<!--
+if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Package avm2.intrinsics.iteration"); titleBar_setSubNav(false,false,false,false,false,false,false,false,false,false,true,false,false,false);}
+--></script>
+<div class="MainContent">
+<br>
+<p>The amv2.intrinsics.iteration package includes the low-level/intrinsic APIs for iterating through an object's properties. These functions are built into the ASC2 compiler and are replaced by single ActionScript ByteCode instructions hence there is no function call overhead when using these.</p>
+<br>
+<hr>
+<a name="methodSummary"></a>
+<div class="summaryTableTitle">Functions</div>
+<table class="summaryTable" cellspacing="0" cellpadding="3">
+<tr>
+<th>&nbsp;</th><th width="30%">Function</th><th width="70%">Description</th>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a href="package.html#hasnext()">hasnext</a></td><td class="summaryTableLastCol">
+
+	 Determine whether the given object has any more properties.</td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a href="package.html#nextname()">nextname</a></td><td class="summaryTableLastCol">
+
+	 Get the name of the next property.</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a href="package.html#nextvalue()">nextvalue</a></td><td class="summaryTableLastCol">
+
+	 Get the value of the next property.</td>
+</tr>
+</table>
+<p></p>
+<div>
+<p></p>
+<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Mon Jun 30 2025, 11:00 AM GMT+01:00<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
+</div>
+</div>
+</body>
+</html><!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Mon Jun 30 2025, 11:00 AM GMT+01:00 <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->

--- a/static/reference/actionscript/3.0/avm2/intrinsics/iteration/package.html
+++ b/static/reference/actionscript/3.0/avm2/intrinsics/iteration/package.html
@@ -1,0 +1,245 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!-- saved from url=(0014)about:internet -->
+<html>
+<head>
+<META http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<link rel="stylesheet" href="../../../style.css" type="text/css" media="screen">
+<link rel="stylesheet" href="../../../print.css" type="text/css" media="print">
+<title>avm2.intrinsics.iteration Details (ActionScript 3.0)</title>
+</head>
+<body>
+<script type="text/javascript" language="javascript" src="../../../asdoc.js"></script><script type="text/javascript" language="javascript" src="../../../cookies.js"></script><script type="text/javascript" language="javascript">
+<!--
+				asdocTitle = 'avm2.intrinsics.iteration Package - ActionScript 3.0 Language Reference';
+				var baseRef = '../../../';
+				window.onload = configPage;
+			--></script>
+<table style="display:none" id="titleTable" cellspacing="0" cellpadding="0" class="titleTable">
+<tr>
+<td align="left" class="titleTableTitle">ActionScript 3.0 Language Reference</td><td align="right" class="titleTableTopNav"><a onclick="loadClassListFrame('../../../all-classes.html')" href="../../../package-summary.html">All&nbsp;Packages</a>&nbsp;|&nbsp;<a onclick="loadClassListFrame('../../../all-classes.html')" href="../../../class-summary.html">All&nbsp;Classes</a>&nbsp;|&nbsp;<a href="../../../language-elements.html">Language&nbsp;Elements</a>&nbsp;| <a onclick="loadClassListFrame('../../../index-list.html')" href="../../../all-index-Symbols.html">Index</a>&nbsp;|&nbsp;<a href="../../../appendices.html">Appendices</a>&nbsp;|&nbsp;<a href="../../../conventions.html">Conventions</a>&nbsp;|&nbsp;<a href="../../../index.html?avm2/intrinsics/iteration/package.html&amp;avm2/intrinsics/iteration/class-list.html" id="framesLink1">Frames</a><a onclick="parent.location=document.location" href="" style="display:none" id="noFramesLink1">No&nbsp;Frames</a></td><td rowspan="3" align="right" class="titleTableLogo"><img alt="Adobe Logo" title="Adobe Logo" class="logoImage" src="../../../images/logo.jpg"></td>
+</tr>
+<tr class="titleTableRow2">
+<td align="left" id="subTitle" class="titleTableSubTitle">Package&nbsp;avm2.intrinsics.iteration</td><td align="right" id="subNav" class="titleTableSubNav"><a href="package.html#methodSummary">Functions</a></td>
+</tr>
+<tr class="titleTableRow3">
+<td colspan="2">&nbsp;</td>
+</tr>
+</table>
+<script type="text/javascript" language="javascript">
+<!--
+if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Package avm2.intrinsics.iteration"); titleBar_setSubNav(false,false,false,false,false,false,false,false,false,false,true,false,false,false);}
+--></script>
+<div class="MainContent">
+<br>
+<a name="methodSummary"></a>Function details for the avm2.intrinsics.iteration package.<div class="summarySection">
+<div class="summaryTableTitle">Public Functions</div>
+<table id="summaryTableMethod" class="summaryTable " cellpadding="3" cellspacing="0">
+<tr>
+<th>&nbsp;</th><th colspan="2">Function</th><th class="summaryTableOwnerCol">Defined&nbsp;by</th>
+</tr>
+<tr class="">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol">
+<div class="summarySignature">
+<a class="signatureLink" href="#hasnext()">hasnext</a>(obj:<a href="../../../Object.html">Object</a>, idx:<a href="../../../int.html">int</a>):<a href="../../../int.html">int</a>
+</div>
+<div class="summaryTableDescription">
+
+	 Determine whether the given object has any more properties.</div>
+</td><td class="summaryTableOwnerCol">avm2.intrinsics.iteration</td>
+</tr>
+<tr class="">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol">
+<div class="summarySignature">
+<a class="signatureLink" href="#nextname()">nextname</a>(obj:<a href="../../../Object.html">Object</a>, idx:<a href="../../../int.html">int</a>):<a href="../../../String.html">String</a>
+</div>
+<div class="summaryTableDescription">
+
+	 Get the name of the next property.</div>
+</td><td class="summaryTableOwnerCol">avm2.intrinsics.iteration</td>
+</tr>
+<tr class="">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol">
+<div class="summarySignature">
+<a class="signatureLink" href="#nextvalue()">nextvalue</a>(obj:<a href="../../../Object.html">Object</a>, idx:<a href="../../../int.html">int</a>):<a href="../../../specialTypes.html#*">*</a>
+</div>
+<div class="summaryTableDescription">
+
+	 Get the value of the next property.</div>
+</td><td class="summaryTableOwnerCol">avm2.intrinsics.iteration</td>
+</tr>
+</table>
+</div>
+<a name="methodDetail"></a>
+<div class="detailSectionHeader">Function detail</div>
+<a name="hasnext()"></a>
+<table cellspacing="0" cellpadding="0" class="detailHeader">
+<tr>
+<td class="detailHeaderName">hasnext</td><td class="detailHeaderParens">()</td><td class="detailHeaderType">function</td>
+</tr>
+</table>
+<div class="detailBody">
+<code>public function hasnext(obj:<a href="../../../Object.html">Object</a>, idx:<a href="../../../int.html">int</a>):<a href="../../../int.html">int</a></code>
+<p></p>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+	 </td>
+</tr>
+</table>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3.6
+
+	</td>
+</tr>
+</table>
+<p></p><p>
+
+	 Determine whether the given object has any more properties.
+
+	 </p><span class="label">Parameters</span>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td width="20px"></td><td><code><span class="label">obj</span>:<a href="../../../Object.html">Object</a></code> &mdash; The object to test for properties.
+
+	 </td>
+</tr>
+<tr>
+<td class="paramSpacer">&nbsp;</td>
+</tr>
+<tr>
+<td width="20px"></td><td><code><span class="label">idx</span>:<a href="../../../int.html">int</a></code> &mdash; The previous property index (or zero to get the first property index).
+
+	 </td>
+</tr>
+</table>
+<p></p>
+<span class="label">Returns</span>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td width="20"></td><td><code><a href="../../../int.html">int</a></code> &mdash; 
+                  Returns the next property index for this object, or zero if there are no more properties.
+
+	 
+                  
+               </td>
+</tr>
+</table>
+</div>
+<a name="nextname()"></a>
+<table cellspacing="0" cellpadding="0" class="detailHeader">
+<tr>
+<td class="detailHeaderName">nextname</td><td class="detailHeaderParens">()</td><td class="detailHeaderType">function</td><td class="detailHeaderRule">&nbsp;</td>
+</tr>
+</table>
+<div class="detailBody">
+<code>public function nextname(obj:<a href="../../../Object.html">Object</a>, idx:<a href="../../../int.html">int</a>):<a href="../../../String.html">String</a></code>
+<p></p>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+	 </td>
+</tr>
+</table>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3.6
+
+	</td>
+</tr>
+</table>
+<p></p><p>
+
+	 Get the name of the next property.
+
+	 </p><span class="label">Parameters</span>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td width="20px"></td><td><code><span class="label">obj</span>:<a href="../../../Object.html">Object</a></code> &mdash; The object for which to get a property name.
+
+	 </td>
+</tr>
+<tr>
+<td class="paramSpacer">&nbsp;</td>
+</tr>
+<tr>
+<td width="20px"></td><td><code><span class="label">idx</span>:<a href="../../../int.html">int</a></code> &mdash; The property index (as returned by <code>hasnext</code>).
+
+	 </td>
+</tr>
+</table>
+<p></p>
+<span class="label">Returns</span>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td width="20"></td><td><code><a href="../../../String.html">String</a></code> &mdash; 
+                  Returns the property's name based on the provided index, or null if this is an invalid index.
+
+	 
+                  
+               </td>
+</tr>
+</table>
+</div>
+<a name="nextvalue()"></a>
+<table cellspacing="0" cellpadding="0" class="detailHeader">
+<tr>
+<td class="detailHeaderName">nextvalue</td><td class="detailHeaderParens">()</td><td class="detailHeaderType">function</td><td class="detailHeaderRule">&nbsp;</td>
+</tr>
+</table>
+<div class="detailBody">
+<code>public function nextvalue(obj:<a href="../../../Object.html">Object</a>, idx:<a href="../../../int.html">int</a>):<a href="../../../specialTypes.html#*">*</a></code>
+<p></p>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+	 </td>
+</tr>
+</table>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3.6
+
+	</td>
+</tr>
+</table>
+<p></p><p>
+
+	 Get the value of the next property.
+
+	 </p><span class="label">Parameters</span>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td width="20px"></td><td><code><span class="label">obj</span>:<a href="../../../Object.html">Object</a></code> &mdash; The object for which to get a property value.
+
+	 </td>
+</tr>
+<tr>
+<td class="paramSpacer">&nbsp;</td>
+</tr>
+<tr>
+<td width="20px"></td><td><code><span class="label">idx</span>:<a href="../../../int.html">int</a></code> &mdash; The property index (as returned by <code>hasnext</code>).
+
+	 </td>
+</tr>
+</table>
+<p></p>
+<span class="label">Returns</span>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td width="20"></td><td><code><a href="../../../specialTypes.html#*">*</a></code> &mdash; Returns the property's value based on the provided index, or undefined if this is an invalid index.
+
+	 </td>
+</tr>
+</table>
+</div>
+<p></p>
+<div class="feedbackLink">
+<center>
+<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Mon Jun 30 2025, 11:00 AM GMT+01:00) : Package avm2.intrinsics.iteration">Submit Feedback</a>
+</center>
+</div>
+<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Mon Jun 30 2025, 11:00 AM GMT+01:00<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
+</div>
+</body>
+</html>

--- a/static/reference/actionscript/3.0/avm2/intrinsics/memory/class-list.html
+++ b/static/reference/actionscript/3.0/avm2/intrinsics/memory/class-list.html
@@ -1,0 +1,69 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!-- saved from url=(0014)about:internet -->
+<html>
+<head>
+<META http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>avm2.intrinsics.memory - ActionScript&nbsp;3.0&nbsp;Language&nbsp;Reference</title>
+<base target="classFrame">
+<link rel="stylesheet" href="../../../style.css" type="text/css" media="screen">
+<link rel="stylesheet" href="../../../print.css" type="text/css" media="print">
+</head>
+<body class="classFrameContent">
+<h3>
+<a style="color:black" target="classFrame" href="package-detail.html">Package avm2.intrinsics.memory</a>
+</h3>
+<table cellspacing="0" cellpadding="0">
+<tr>
+<td><a style="color:black" href="package.html#methodSummary"><b>Functions</b></a></td>
+</tr>
+<tr>
+<td><a href="package.html#casi32()">casi32()</a></td>
+</tr>
+<tr>
+<td><a href="package.html#lf32()">lf32()</a></td>
+</tr>
+<tr>
+<td><a href="package.html#lf64()">lf64()</a></td>
+</tr>
+<tr>
+<td><a href="package.html#li16()">li16()</a></td>
+</tr>
+<tr>
+<td><a href="package.html#li32()">li32()</a></td>
+</tr>
+<tr>
+<td><a href="package.html#li8()">li8()</a></td>
+</tr>
+<tr>
+<td><a href="package.html#mfence()">mfence()</a></td>
+</tr>
+<tr>
+<td><a href="package.html#sf32()">sf32()</a></td>
+</tr>
+<tr>
+<td><a href="package.html#sf64()">sf64()</a></td>
+</tr>
+<tr>
+<td><a href="package.html#si16()">si16()</a></td>
+</tr>
+<tr>
+<td><a href="package.html#si32()">si32()</a></td>
+</tr>
+<tr>
+<td><a href="package.html#si8()">si8()</a></td>
+</tr>
+<tr>
+<td><a href="package.html#sxi1()">sxi1()</a></td>
+</tr>
+<tr>
+<td><a href="package.html#sxi16()">sxi16()</a></td>
+</tr>
+<tr>
+<td><a href="package.html#sxi8()">sxi8()</a></td>
+</tr>
+<tr>
+<td width="10px">&nbsp;</td>
+</tr>
+</table>
+</body>
+</html><!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Mon Jun 30 2025, 11:00 AM GMT+01:00 <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->

--- a/static/reference/actionscript/3.0/avm2/intrinsics/memory/package-detail.html
+++ b/static/reference/actionscript/3.0/avm2/intrinsics/memory/package-detail.html
@@ -1,0 +1,126 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!-- saved from url=(0014)about:internet -->
+<html>
+<head>
+<META http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<link rel="stylesheet" href="../../../style.css" type="text/css" media="screen">
+<link rel="stylesheet" href="../../../print.css" type="text/css" media="print">
+<title>avm2.intrinsics.memory Summary (ActionScript 3.0)</title>
+</head>
+<body>
+<script type="text/javascript" language="javascript" src="../../../asdoc.js"></script><script type="text/javascript" language="javascript" src="../../../cookies.js"></script><script type="text/javascript" language="javascript">
+<!--
+				asdocTitle = 'avm2.intrinsics.memory Package - ActionScript 3.0 Language Reference';
+				var baseRef = '../../../';
+				window.onload = configPage;
+			--></script>
+<table style="display:none" id="titleTable" cellspacing="0" cellpadding="0" class="titleTable">
+<tr>
+<td align="left" class="titleTableTitle">ActionScript 3.0 Language Reference</td><td align="right" class="titleTableTopNav"><a onclick="loadClassListFrame('../../../all-classes.html')" href="../../../package-summary.html">All&nbsp;Packages</a>&nbsp;|&nbsp;<a onclick="loadClassListFrame('../../../all-classes.html')" href="../../../class-summary.html">All&nbsp;Classes</a>&nbsp;|&nbsp;<a href="../../../language-elements.html">Language&nbsp;Elements</a>&nbsp;| <a onclick="loadClassListFrame('../../../index-list.html')" href="../../../all-index-Symbols.html">Index</a>&nbsp;|&nbsp;<a href="../../../appendices.html">Appendices</a>&nbsp;|&nbsp;<a href="../../../conventions.html">Conventions</a>&nbsp;|&nbsp;<a href="../../../index.html?avm2/intrinsics/memory/package-detail.html&amp;avm2/intrinsics/memory/class-list.html" id="framesLink1">Frames</a><a onclick="parent.location=document.location" href="" style="display:none" id="noFramesLink1">No&nbsp;Frames</a></td><td rowspan="3" align="right" class="titleTableLogo"><img alt="Adobe Logo" title="Adobe Logo" class="logoImage" src="../../../images/logo.jpg"></td>
+</tr>
+<tr class="titleTableRow2">
+<td align="left" id="subTitle" class="titleTableSubTitle">Package&nbsp;avm2.intrinsics.memory</td><td align="right" id="subNav" class="titleTableSubNav"><a href="package.html#methodSummary">Functions</a></td>
+</tr>
+<tr class="titleTableRow3">
+<td colspan="2">&nbsp;</td>
+</tr>
+</table>
+<script type="text/javascript" language="javascript">
+<!--
+if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Package avm2.intrinsics.memory"); titleBar_setSubNav(false,false,false,false,false,false,false,false,false,false,true,false,false,false);}
+--></script>
+<div class="MainContent">
+<br>
+<p>The amv2.intrinsics.memory package includes the low-level/intrinsic memory access APIs for loading and storing values into the application's domain memory, and for concurrency operations. Most of these functions are built into the ASC2 compiler and are replaced by single ActionScript ByteCode instructions hence eliminating the overhead involved in function calls. The concurrency utilities (mfence and casi32) are native C++ method calls.</p>
+<br>
+<hr>
+<a name="methodSummary"></a>
+<div class="summaryTableTitle">Functions</div>
+<table class="summaryTable" cellspacing="0" cellpadding="3">
+<tr>
+<th>&nbsp;</th><th width="30%">Function</th><th width="70%">Description</th>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a href="package.html#casi32()">casi32</a></td><td class="summaryTableLastCol">
+
+     A compare-and-swap operation for domainMemory.</td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a href="package.html#lf32()">lf32</a></td><td class="summaryTableLastCol">
+
+	 Loads a 32-bit floating point value from the given <code>addr</code> in domain memory.</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a href="package.html#lf64()">lf64</a></td><td class="summaryTableLastCol">
+
+	 Loads a 64-bit floating point value from the given <code>addr</code> in domain memory.</td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a href="package.html#li16()">li16</a></td><td class="summaryTableLastCol">
+
+	 Loads a 16-bit integer value from the given <code>addr</code> in domain memory.</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a href="package.html#li32()">li32</a></td><td class="summaryTableLastCol">
+
+	 Loads a 32-bit integer value from the given <code>addr</code> in domain memory.</td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a href="package.html#li8()">li8</a></td><td class="summaryTableLastCol">
+
+	 Loads an 8-bit integer value from the given <code>addr</code> in domain memory.</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a href="package.html#mfence()">mfence</a></td><td class="summaryTableLastCol">
+
+     A complete memory barrier for domainMemory (for both load and store instructions).</td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a href="package.html#sf32()">sf32</a></td><td class="summaryTableLastCol">
+
+	 Stores a 32-bit floating point value into the given <code>addr</code> in domain memory.</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a href="package.html#sf64()">sf64</a></td><td class="summaryTableLastCol">
+
+	 Stores a 64-bit floating point value into the given <code>addr</code> in domain memory.</td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a href="package.html#si16()">si16</a></td><td class="summaryTableLastCol">
+
+	 Stores a 16-bit integer value into the given <code>addr</code> in domain memory.</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a href="package.html#si32()">si32</a></td><td class="summaryTableLastCol">
+
+	 Stores a 32-bit integer value into the given <code>addr</code> in domain memory.</td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a href="package.html#si8()">si8</a></td><td class="summaryTableLastCol">
+
+	 Stores an 8-bit integer value into the given <code>addr</code> in domain memory.</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a href="package.html#sxi1()">sxi1</a></td><td class="summaryTableLastCol">
+
+	 Sign-extends a 1-bit integer value to a 32-bit integer value.</td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a href="package.html#sxi16()">sxi16</a></td><td class="summaryTableLastCol">
+
+	 Sign-extends a 16-bit integer value to a 32-bit integer value.</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a href="package.html#sxi8()">sxi8</a></td><td class="summaryTableLastCol">
+
+	 Sign-extends an 8-bit integer value to a 32-bit integer value.</td>
+</tr>
+</table>
+<p></p>
+<div>
+<p></p>
+<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Mon Jun 30 2025, 11:00 AM GMT+01:00<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
+</div>
+</div>
+</body>
+</html><!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Mon Jun 30 2025, 11:00 AM GMT+01:00 <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->

--- a/static/reference/actionscript/3.0/avm2/intrinsics/memory/package.html
+++ b/static/reference/actionscript/3.0/avm2/intrinsics/memory/package.html
@@ -1,0 +1,968 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!-- saved from url=(0014)about:internet -->
+<html>
+<head>
+<META http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<link rel="stylesheet" href="../../../style.css" type="text/css" media="screen">
+<link rel="stylesheet" href="../../../print.css" type="text/css" media="print">
+<title>avm2.intrinsics.memory Details (ActionScript 3.0)</title>
+</head>
+<body>
+<script type="text/javascript" language="javascript" src="../../../asdoc.js"></script><script type="text/javascript" language="javascript" src="../../../cookies.js"></script><script type="text/javascript" language="javascript">
+<!--
+				asdocTitle = 'avm2.intrinsics.memory Package - ActionScript 3.0 Language Reference';
+				var baseRef = '../../../';
+				window.onload = configPage;
+			--></script>
+<table style="display:none" id="titleTable" cellspacing="0" cellpadding="0" class="titleTable">
+<tr>
+<td align="left" class="titleTableTitle">ActionScript 3.0 Language Reference</td><td align="right" class="titleTableTopNav"><a onclick="loadClassListFrame('../../../all-classes.html')" href="../../../package-summary.html">All&nbsp;Packages</a>&nbsp;|&nbsp;<a onclick="loadClassListFrame('../../../all-classes.html')" href="../../../class-summary.html">All&nbsp;Classes</a>&nbsp;|&nbsp;<a href="../../../language-elements.html">Language&nbsp;Elements</a>&nbsp;| <a onclick="loadClassListFrame('../../../index-list.html')" href="../../../all-index-Symbols.html">Index</a>&nbsp;|&nbsp;<a href="../../../appendices.html">Appendices</a>&nbsp;|&nbsp;<a href="../../../conventions.html">Conventions</a>&nbsp;|&nbsp;<a href="../../../index.html?avm2/intrinsics/memory/package.html&amp;avm2/intrinsics/memory/class-list.html" id="framesLink1">Frames</a><a onclick="parent.location=document.location" href="" style="display:none" id="noFramesLink1">No&nbsp;Frames</a></td><td rowspan="3" align="right" class="titleTableLogo"><img alt="Adobe Logo" title="Adobe Logo" class="logoImage" src="../../../images/logo.jpg"></td>
+</tr>
+<tr class="titleTableRow2">
+<td align="left" id="subTitle" class="titleTableSubTitle">Package&nbsp;avm2.intrinsics.memory</td><td align="right" id="subNav" class="titleTableSubNav"><a href="package.html#methodSummary">Functions</a></td>
+</tr>
+<tr class="titleTableRow3">
+<td colspan="2">&nbsp;</td>
+</tr>
+</table>
+<script type="text/javascript" language="javascript">
+<!--
+if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Package avm2.intrinsics.memory"); titleBar_setSubNav(false,false,false,false,false,false,false,false,false,false,true,false,false,false);}
+--></script>
+<div class="MainContent">
+<br>
+<a name="methodSummary"></a>Function details for the avm2.intrinsics.memory package.<div class="summarySection">
+<div class="summaryTableTitle">Public Functions</div>
+<table id="summaryTableMethod" class="summaryTable " cellpadding="3" cellspacing="0">
+<tr>
+<th>&nbsp;</th><th colspan="2">Function</th><th class="summaryTableOwnerCol">Defined&nbsp;by</th>
+</tr>
+<tr class="">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol">
+<div class="summarySignature">
+<a class="signatureLink" href="#casi32()">casi32</a>(addr:<a href="../../../int.html">int</a>, expectedVal:<a href="../../../int.html">int</a>, newVal:<a href="../../../int.html">int</a>):<a href="../../../int.html">int</a>
+</div>
+<div class="summaryTableDescription">
+
+     A compare-and-swap operation for domainMemory.</div>
+</td><td class="summaryTableOwnerCol">avm2.intrinsics.memory</td>
+</tr>
+<tr class="">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol">
+<div class="summarySignature">
+<a class="signatureLink" href="#lf32()">lf32</a>(addr:<a href="../../../int.html">int</a>):<a href="../../../Number.html">Number</a>
+</div>
+<div class="summaryTableDescription">
+
+	 Loads a 32-bit floating point value from the given <code>addr</code> in domain memory.</div>
+</td><td class="summaryTableOwnerCol">avm2.intrinsics.memory</td>
+</tr>
+<tr class="">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol">
+<div class="summarySignature">
+<a class="signatureLink" href="#lf64()">lf64</a>(addr:<a href="../../../int.html">int</a>):<a href="../../../Number.html">Number</a>
+</div>
+<div class="summaryTableDescription">
+
+	 Loads a 64-bit floating point value from the given <code>addr</code> in domain memory.</div>
+</td><td class="summaryTableOwnerCol">avm2.intrinsics.memory</td>
+</tr>
+<tr class="">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol">
+<div class="summarySignature">
+<a class="signatureLink" href="#li16()">li16</a>(addr:<a href="../../../int.html">int</a>):<a href="../../../int.html">int</a>
+</div>
+<div class="summaryTableDescription">
+
+	 Loads a 16-bit integer value from the given <code>addr</code> in domain memory.</div>
+</td><td class="summaryTableOwnerCol">avm2.intrinsics.memory</td>
+</tr>
+<tr class="">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol">
+<div class="summarySignature">
+<a class="signatureLink" href="#li32()">li32</a>(addr:<a href="../../../int.html">int</a>):<a href="../../../int.html">int</a>
+</div>
+<div class="summaryTableDescription">
+
+	 Loads a 32-bit integer value from the given <code>addr</code> in domain memory.</div>
+</td><td class="summaryTableOwnerCol">avm2.intrinsics.memory</td>
+</tr>
+<tr class="">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol">
+<div class="summarySignature">
+<a class="signatureLink" href="#li8()">li8</a>(addr:<a href="../../../int.html">int</a>):<a href="../../../int.html">int</a>
+</div>
+<div class="summaryTableDescription">
+
+	 Loads an 8-bit integer value from the given <code>addr</code> in domain memory.</div>
+</td><td class="summaryTableOwnerCol">avm2.intrinsics.memory</td>
+</tr>
+<tr class="">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol">
+<div class="summarySignature">
+<a class="signatureLink" href="#mfence()">mfence</a>():<a href="../../../specialTypes.html#void">void</a>
+</div>
+<div class="summaryTableDescription">
+
+     A complete memory barrier for domainMemory (for both load and store instructions).</div>
+</td><td class="summaryTableOwnerCol">avm2.intrinsics.memory</td>
+</tr>
+<tr class="">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol">
+<div class="summarySignature">
+<a class="signatureLink" href="#sf32()">sf32</a>(value:<a href="../../../Number.html">Number</a>, addr:<a href="../../../int.html">int</a>):<a href="../../../specialTypes.html#void">void</a>
+</div>
+<div class="summaryTableDescription">
+
+	 Stores a 32-bit floating point value into the given <code>addr</code> in domain memory.</div>
+</td><td class="summaryTableOwnerCol">avm2.intrinsics.memory</td>
+</tr>
+<tr class="">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol">
+<div class="summarySignature">
+<a class="signatureLink" href="#sf64()">sf64</a>(value:<a href="../../../Number.html">Number</a>, addr:<a href="../../../int.html">int</a>):<a href="../../../specialTypes.html#void">void</a>
+</div>
+<div class="summaryTableDescription">
+
+	 Stores a 64-bit floating point value into the given <code>addr</code> in domain memory.</div>
+</td><td class="summaryTableOwnerCol">avm2.intrinsics.memory</td>
+</tr>
+<tr class="">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol">
+<div class="summarySignature">
+<a class="signatureLink" href="#si16()">si16</a>(value:<a href="../../../int.html">int</a>, addr:<a href="../../../int.html">int</a>):<a href="../../../specialTypes.html#void">void</a>
+</div>
+<div class="summaryTableDescription">
+
+	 Stores a 16-bit integer value into the given <code>addr</code> in domain memory.</div>
+</td><td class="summaryTableOwnerCol">avm2.intrinsics.memory</td>
+</tr>
+<tr class="">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol">
+<div class="summarySignature">
+<a class="signatureLink" href="#si32()">si32</a>(value:<a href="../../../int.html">int</a>, addr:<a href="../../../int.html">int</a>):<a href="../../../specialTypes.html#void">void</a>
+</div>
+<div class="summaryTableDescription">
+
+	 Stores a 32-bit integer value into the given <code>addr</code> in domain memory.</div>
+</td><td class="summaryTableOwnerCol">avm2.intrinsics.memory</td>
+</tr>
+<tr class="">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol">
+<div class="summarySignature">
+<a class="signatureLink" href="#si8()">si8</a>(value:<a href="../../../int.html">int</a>, addr:<a href="../../../int.html">int</a>):<a href="../../../specialTypes.html#void">void</a>
+</div>
+<div class="summaryTableDescription">
+
+	 Stores an 8-bit integer value into the given <code>addr</code> in domain memory.</div>
+</td><td class="summaryTableOwnerCol">avm2.intrinsics.memory</td>
+</tr>
+<tr class="">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol">
+<div class="summarySignature">
+<a class="signatureLink" href="#sxi1()">sxi1</a>(value:<a href="../../../int.html">int</a>):<a href="../../../int.html">int</a>
+</div>
+<div class="summaryTableDescription">
+
+	 Sign-extends a 1-bit integer value to a 32-bit integer value.</div>
+</td><td class="summaryTableOwnerCol">avm2.intrinsics.memory</td>
+</tr>
+<tr class="">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol">
+<div class="summarySignature">
+<a class="signatureLink" href="#sxi16()">sxi16</a>(value:<a href="../../../int.html">int</a>):<a href="../../../int.html">int</a>
+</div>
+<div class="summaryTableDescription">
+
+	 Sign-extends a 16-bit integer value to a 32-bit integer value.</div>
+</td><td class="summaryTableOwnerCol">avm2.intrinsics.memory</td>
+</tr>
+<tr class="">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol">
+<div class="summarySignature">
+<a class="signatureLink" href="#sxi8()">sxi8</a>(value:<a href="../../../int.html">int</a>):<a href="../../../int.html">int</a>
+</div>
+<div class="summaryTableDescription">
+
+	 Sign-extends an 8-bit integer value to a 32-bit integer value.</div>
+</td><td class="summaryTableOwnerCol">avm2.intrinsics.memory</td>
+</tr>
+</table>
+</div>
+<a name="methodDetail"></a>
+<div class="detailSectionHeader">Function detail</div>
+<a name="casi32()"></a>
+<table cellspacing="0" cellpadding="0" class="detailHeader">
+<tr>
+<td class="detailHeaderName">casi32</td><td class="detailHeaderParens">()</td><td class="detailHeaderType">function</td>
+</tr>
+</table>
+<div class="detailBody">
+<code>public function casi32(addr:<a href="../../../int.html">int</a>, expectedVal:<a href="../../../int.html">int</a>, newVal:<a href="../../../int.html">int</a>):<a href="../../../int.html">int</a></code>
+<p></p>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     </td>
+</tr>
+</table>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3.6
+
+</td>
+</tr>
+</table>
+<p></p><p>
+
+     A compare-and-swap operation for domainMemory.
+
+     This behaves like the <code>ByteArray.atomicCompareAndSwapIntAt</code> method, but operates on the
+
+     current domain memory. The 32-bit value found at the <code>addr</code> offset into domain memory is
+
+     checked, and if this is equal to the <code>expectedValue</code> value, then the <code>newValue</code>
+
+     value is written into this offset, and the old (expected) value is returned. Otherwise, the domain
+
+     memory is not updated, and the actual value found at this address is returned.
+
+     </p><span class="label">Parameters</span>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td width="20px"></td><td><code><span class="label">addr</span>:<a href="../../../int.html">int</a></code> &mdash; The address/offset into the domain memory byte array at which to perform the compare/swap operation.
+
+     </td>
+</tr>
+<tr>
+<td class="paramSpacer">&nbsp;</td>
+</tr>
+<tr>
+<td width="20px"></td><td><code><span class="label">expectedVal</span>:<a href="../../../int.html">int</a></code> &mdash; Contains the expected value of the integer to be replaced by the newValue parameter.
+
+     </td>
+</tr>
+<tr>
+<td class="paramSpacer">&nbsp;</td>
+</tr>
+<tr>
+<td width="20px"></td><td><code><span class="label">newVal</span>:<a href="../../../int.html">int</a></code> &mdash; The new value to put into the location at the addr offset, if the existing value equals the exptectedValue parameter.
+
+     </td>
+</tr>
+</table>
+<p></p>
+<span class="label">Returns</span>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td width="20"></td><td><code><a href="../../../int.html">int</a></code> &mdash; 
+                  Returns the previous value at the specified offset into the domain memory.
+
+     
+                  
+               </td>
+</tr>
+</table>
+<p>
+<span class="label">See also</span>
+</p>
+<div class="seeAlso">
+<a href="../../../flash/system/ApplicationDomain.html#domainMemory" target="">ApplicationDomain domainMemory property</a>
+<br>
+<a href="../../../flash/utils/ByteArray.html#atomicCompareAndSwapIntAt()" target="">ByteArray.atomicCompareAndSwapIntAt() method.</a>
+</div>
+</div>
+<a name="lf32()"></a>
+<table cellspacing="0" cellpadding="0" class="detailHeader">
+<tr>
+<td class="detailHeaderName">lf32</td><td class="detailHeaderParens">()</td><td class="detailHeaderType">function</td><td class="detailHeaderRule">&nbsp;</td>
+</tr>
+</table>
+<div class="detailBody">
+<code>public function lf32(addr:<a href="../../../int.html">int</a>):<a href="../../../Number.html">Number</a></code>
+<p></p>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+	 </td>
+</tr>
+</table>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3.6
+
+	</td>
+</tr>
+</table>
+<p></p><p>
+
+	 Loads a 32-bit floating point value from the given <code>addr</code> in domain memory.
+
+	 </p><span class="label">Parameters</span>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td width="20px"></td><td><code><span class="label">addr</span>:<a href="../../../int.html">int</a></code> &mdash; The address/offset into the domain memory byte array from which to load the value.
+
+	 </td>
+</tr>
+</table>
+<p></p>
+<span class="label">Returns</span>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td width="20"></td><td><code><a href="../../../Number.html">Number</a></code> &mdash; 
+                  Returns the 32-bit single-precision floating point value found at this memory location.
+
+	 
+                  
+               </td>
+</tr>
+</table>
+<p>
+<span class="label">See also</span>
+</p>
+<div class="seeAlso">
+<a href="../../../flash/system/ApplicationDomain.html#domainMemory" target="">ApplicationDomain domainMemory property</a>
+</div>
+</div>
+<a name="lf64()"></a>
+<table cellspacing="0" cellpadding="0" class="detailHeader">
+<tr>
+<td class="detailHeaderName">lf64</td><td class="detailHeaderParens">()</td><td class="detailHeaderType">function</td><td class="detailHeaderRule">&nbsp;</td>
+</tr>
+</table>
+<div class="detailBody">
+<code>public function lf64(addr:<a href="../../../int.html">int</a>):<a href="../../../Number.html">Number</a></code>
+<p></p>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+	 </td>
+</tr>
+</table>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3.6
+
+	</td>
+</tr>
+</table>
+<p></p><p>
+
+	 Loads a 64-bit floating point value from the given <code>addr</code> in domain memory.
+
+	 </p><span class="label">Parameters</span>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td width="20px"></td><td><code><span class="label">addr</span>:<a href="../../../int.html">int</a></code> &mdash; The address/offset into the domain memory byte array from which to load the value.
+
+	 </td>
+</tr>
+</table>
+<p></p>
+<span class="label">Returns</span>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td width="20"></td><td><code><a href="../../../Number.html">Number</a></code> &mdash; 
+                  Returns the 64-bit double-precsision floating point value found at this memory location.
+
+	 
+                  
+               </td>
+</tr>
+</table>
+<p>
+<span class="label">See also</span>
+</p>
+<div class="seeAlso">
+<a href="../../../flash/system/ApplicationDomain.html#domainMemory" target="">ApplicationDomain domainMemory property</a>
+</div>
+</div>
+<a name="li16()"></a>
+<table cellspacing="0" cellpadding="0" class="detailHeader">
+<tr>
+<td class="detailHeaderName">li16</td><td class="detailHeaderParens">()</td><td class="detailHeaderType">function</td><td class="detailHeaderRule">&nbsp;</td>
+</tr>
+</table>
+<div class="detailBody">
+<code>public function li16(addr:<a href="../../../int.html">int</a>):<a href="../../../int.html">int</a></code>
+<p></p>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+	 </td>
+</tr>
+</table>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3.6
+
+	</td>
+</tr>
+</table>
+<p></p><p>
+
+	 Loads a 16-bit integer value from the given <code>addr</code> in domain memory.
+
+	 </p><span class="label">Parameters</span>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td width="20px"></td><td><code><span class="label">addr</span>:<a href="../../../int.html">int</a></code> &mdash; The address/offset into the domain memory byte array from which to load the value.
+
+	 </td>
+</tr>
+</table>
+<p></p>
+<span class="label">Returns</span>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td width="20"></td><td><code><a href="../../../int.html">int</a></code> &mdash; 
+                  Returns the 16-bit integer value found at this memory location.
+
+	 
+                  
+               </td>
+</tr>
+</table>
+<p>
+<span class="label">See also</span>
+</p>
+<div class="seeAlso">
+<a href="../../../flash/system/ApplicationDomain.html#domainMemory" target="">ApplicationDomain domainMemory property</a>
+</div>
+</div>
+<a name="li32()"></a>
+<table cellspacing="0" cellpadding="0" class="detailHeader">
+<tr>
+<td class="detailHeaderName">li32</td><td class="detailHeaderParens">()</td><td class="detailHeaderType">function</td><td class="detailHeaderRule">&nbsp;</td>
+</tr>
+</table>
+<div class="detailBody">
+<code>public function li32(addr:<a href="../../../int.html">int</a>):<a href="../../../int.html">int</a></code>
+<p></p>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+	 </td>
+</tr>
+</table>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3.6
+
+	</td>
+</tr>
+</table>
+<p></p><p>
+
+	 Loads a 32-bit integer value from the given <code>addr</code> in domain memory.
+
+	 </p><span class="label">Parameters</span>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td width="20px"></td><td><code><span class="label">addr</span>:<a href="../../../int.html">int</a></code> &mdash; The address/offset into the domain memory byte array from which to load the value.
+
+	 </td>
+</tr>
+</table>
+<p></p>
+<span class="label">Returns</span>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td width="20"></td><td><code><a href="../../../int.html">int</a></code> &mdash; 
+                  Returns the 32-bit integer value found at this memory location.
+
+	 
+                  
+               </td>
+</tr>
+</table>
+<p>
+<span class="label">See also</span>
+</p>
+<div class="seeAlso">
+<a href="../../../flash/system/ApplicationDomain.html#domainMemory" target="">ApplicationDomain domainMemory property</a>
+</div>
+</div>
+<a name="li8()"></a>
+<table cellspacing="0" cellpadding="0" class="detailHeader">
+<tr>
+<td class="detailHeaderName">li8</td><td class="detailHeaderParens">()</td><td class="detailHeaderType">function</td><td class="detailHeaderRule">&nbsp;</td>
+</tr>
+</table>
+<div class="detailBody">
+<code>public function li8(addr:<a href="../../../int.html">int</a>):<a href="../../../int.html">int</a></code>
+<p></p>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+	 </td>
+</tr>
+</table>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3.6
+
+	</td>
+</tr>
+</table>
+<p></p><p>
+
+	 Loads an 8-bit integer value from the given <code>addr</code> in domain memory.
+
+	 </p><span class="label">Parameters</span>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td width="20px"></td><td><code><span class="label">addr</span>:<a href="../../../int.html">int</a></code> &mdash; The address/offset into the domain memory byte array from which to load the value.
+
+	 </td>
+</tr>
+</table>
+<p></p>
+<span class="label">Returns</span>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td width="20"></td><td><code><a href="../../../int.html">int</a></code> &mdash; 
+                  Returns the 8-bit integer value found at this memory location.
+
+	 
+                  
+               </td>
+</tr>
+</table>
+<p>
+<span class="label">See also</span>
+</p>
+<div class="seeAlso">
+<a href="../../../flash/system/ApplicationDomain.html#domainMemory" target="">ApplicationDomain domainMemory property</a>
+</div>
+</div>
+<a name="mfence()"></a>
+<table cellspacing="0" cellpadding="0" class="detailHeader">
+<tr>
+<td class="detailHeaderName">mfence</td><td class="detailHeaderParens">()</td><td class="detailHeaderType">function</td><td class="detailHeaderRule">&nbsp;</td>
+</tr>
+</table>
+<div class="detailBody">
+<code>public function mfence():<a href="../../../specialTypes.html#void">void</a></code>
+<p></p>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     </td>
+</tr>
+</table>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3.6
+
+</td>
+</tr>
+</table>
+<p></p><p>
+
+     A complete memory barrier for domainMemory (for both load and store instructions).
+
+     </p><p>
+<span class="label">See also</span>
+</p>
+<div class="seeAlso">
+<a href="../../../flash/system/ApplicationDomain.html#domainMemory" target="">ApplicationDomain domainMemory property</a>
+</div>
+</div>
+<a name="sf32()"></a>
+<table cellspacing="0" cellpadding="0" class="detailHeader">
+<tr>
+<td class="detailHeaderName">sf32</td><td class="detailHeaderParens">()</td><td class="detailHeaderType">function</td><td class="detailHeaderRule">&nbsp;</td>
+</tr>
+</table>
+<div class="detailBody">
+<code>public function sf32(value:<a href="../../../Number.html">Number</a>, addr:<a href="../../../int.html">int</a>):<a href="../../../specialTypes.html#void">void</a></code>
+<p></p>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+	 </td>
+</tr>
+</table>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3.6
+
+	</td>
+</tr>
+</table>
+<p></p><p>
+
+	 Stores a 32-bit floating point value into the given <code>addr</code> in domain memory.
+
+	 </p><span class="label">Parameters</span>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td width="20px"></td><td><code><span class="label">value</span>:<a href="../../../Number.html">Number</a></code> &mdash; The 32-bit single-precision floating point value to be stored into the domain memory.
+
+	 </td>
+</tr>
+<tr>
+<td class="paramSpacer">&nbsp;</td>
+</tr>
+<tr>
+<td width="20px"></td><td><code><span class="label">addr</span>:<a href="../../../int.html">int</a></code> &mdash; The address/offset into the domain memory byte array into which to store the value.
+
+	 </td>
+</tr>
+</table>
+<p>
+<span class="label">See also</span>
+</p>
+<div class="seeAlso">
+<a href="../../../flash/system/ApplicationDomain.html#domainMemory" target="">ApplicationDomain domainMemory property</a>
+</div>
+</div>
+<a name="sf64()"></a>
+<table cellspacing="0" cellpadding="0" class="detailHeader">
+<tr>
+<td class="detailHeaderName">sf64</td><td class="detailHeaderParens">()</td><td class="detailHeaderType">function</td><td class="detailHeaderRule">&nbsp;</td>
+</tr>
+</table>
+<div class="detailBody">
+<code>public function sf64(value:<a href="../../../Number.html">Number</a>, addr:<a href="../../../int.html">int</a>):<a href="../../../specialTypes.html#void">void</a></code>
+<p></p>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+	 </td>
+</tr>
+</table>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3.6
+
+	</td>
+</tr>
+</table>
+<p></p><p>
+
+	 Stores a 64-bit floating point value into the given <code>addr</code> in domain memory.
+
+	 </p><span class="label">Parameters</span>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td width="20px"></td><td><code><span class="label">value</span>:<a href="../../../Number.html">Number</a></code> &mdash; The 64-bit double-precision floating point value to be stored into the domain memory.
+
+	 </td>
+</tr>
+<tr>
+<td class="paramSpacer">&nbsp;</td>
+</tr>
+<tr>
+<td width="20px"></td><td><code><span class="label">addr</span>:<a href="../../../int.html">int</a></code> &mdash; The address/offset into the domain memory byte array into which to store the value.
+
+	 </td>
+</tr>
+</table>
+<p>
+<span class="label">See also</span>
+</p>
+<div class="seeAlso">
+<a href="../../../flash/system/ApplicationDomain.html#domainMemory" target="">ApplicationDomain domainMemory property</a>
+</div>
+</div>
+<a name="si16()"></a>
+<table cellspacing="0" cellpadding="0" class="detailHeader">
+<tr>
+<td class="detailHeaderName">si16</td><td class="detailHeaderParens">()</td><td class="detailHeaderType">function</td><td class="detailHeaderRule">&nbsp;</td>
+</tr>
+</table>
+<div class="detailBody">
+<code>public function si16(value:<a href="../../../int.html">int</a>, addr:<a href="../../../int.html">int</a>):<a href="../../../specialTypes.html#void">void</a></code>
+<p></p>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+	 </td>
+</tr>
+</table>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3.6
+
+	</td>
+</tr>
+</table>
+<p></p><p>
+
+	 Stores a 16-bit integer value into the given <code>addr</code> in domain memory.
+
+	 </p><span class="label">Parameters</span>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td width="20px"></td><td><code><span class="label">value</span>:<a href="../../../int.html">int</a></code> &mdash; The integer value treated as a 16-bit value to be stored into the domain memory.
+
+	 </td>
+</tr>
+<tr>
+<td class="paramSpacer">&nbsp;</td>
+</tr>
+<tr>
+<td width="20px"></td><td><code><span class="label">addr</span>:<a href="../../../int.html">int</a></code> &mdash; The address/offset into the domain memory byte array into which to store the value.
+
+	 </td>
+</tr>
+</table>
+<p>
+<span class="label">See also</span>
+</p>
+<div class="seeAlso">
+<a href="../../../flash/system/ApplicationDomain.html#domainMemory" target="">ApplicationDomain domainMemory property</a>
+</div>
+</div>
+<a name="si32()"></a>
+<table cellspacing="0" cellpadding="0" class="detailHeader">
+<tr>
+<td class="detailHeaderName">si32</td><td class="detailHeaderParens">()</td><td class="detailHeaderType">function</td><td class="detailHeaderRule">&nbsp;</td>
+</tr>
+</table>
+<div class="detailBody">
+<code>public function si32(value:<a href="../../../int.html">int</a>, addr:<a href="../../../int.html">int</a>):<a href="../../../specialTypes.html#void">void</a></code>
+<p></p>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+	 </td>
+</tr>
+</table>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3.6
+
+	</td>
+</tr>
+</table>
+<p></p><p>
+
+	 Stores a 32-bit integer value into the given <code>addr</code> in domain memory.
+
+	 </p><span class="label">Parameters</span>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td width="20px"></td><td><code><span class="label">value</span>:<a href="../../../int.html">int</a></code> &mdash; The integer value to be stored into the domain memory.
+
+	 </td>
+</tr>
+<tr>
+<td class="paramSpacer">&nbsp;</td>
+</tr>
+<tr>
+<td width="20px"></td><td><code><span class="label">addr</span>:<a href="../../../int.html">int</a></code> &mdash; The address/offset into the domain memory byte array into which to store the value.
+
+	 </td>
+</tr>
+</table>
+<p>
+<span class="label">See also</span>
+</p>
+<div class="seeAlso">
+<a href="../../../flash/system/ApplicationDomain.html#domainMemory" target="">ApplicationDomain domainMemory property</a>
+</div>
+</div>
+<a name="si8()"></a>
+<table cellspacing="0" cellpadding="0" class="detailHeader">
+<tr>
+<td class="detailHeaderName">si8</td><td class="detailHeaderParens">()</td><td class="detailHeaderType">function</td><td class="detailHeaderRule">&nbsp;</td>
+</tr>
+</table>
+<div class="detailBody">
+<code>public function si8(value:<a href="../../../int.html">int</a>, addr:<a href="../../../int.html">int</a>):<a href="../../../specialTypes.html#void">void</a></code>
+<p></p>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+	 </td>
+</tr>
+</table>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3.6
+
+	</td>
+</tr>
+</table>
+<p></p><p>
+
+	 Stores an 8-bit integer value into the given <code>addr</code> in domain memory.
+
+	 </p><span class="label">Parameters</span>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td width="20px"></td><td><code><span class="label">value</span>:<a href="../../../int.html">int</a></code> &mdash; The integer value treated as an 8-bit value to be stored into the domain memory.
+
+	 </td>
+</tr>
+<tr>
+<td class="paramSpacer">&nbsp;</td>
+</tr>
+<tr>
+<td width="20px"></td><td><code><span class="label">addr</span>:<a href="../../../int.html">int</a></code> &mdash; The address/offset into the domain memory byte array into which to store the value.
+
+	 </td>
+</tr>
+</table>
+<p>
+<span class="label">See also</span>
+</p>
+<div class="seeAlso">
+<a href="../../../flash/system/ApplicationDomain.html#domainMemory" target="">ApplicationDomain domainMemory property</a>
+</div>
+</div>
+<a name="sxi1()"></a>
+<table cellspacing="0" cellpadding="0" class="detailHeader">
+<tr>
+<td class="detailHeaderName">sxi1</td><td class="detailHeaderParens">()</td><td class="detailHeaderType">function</td><td class="detailHeaderRule">&nbsp;</td>
+</tr>
+</table>
+<div class="detailBody">
+<code>public function sxi1(value:<a href="../../../int.html">int</a>):<a href="../../../int.html">int</a></code>
+<p></p>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+	 </td>
+</tr>
+</table>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3.6
+
+	</td>
+</tr>
+</table>
+<p></p><p>
+
+	 Sign-extends a 1-bit integer value to a 32-bit integer value.
+
+	 </p><span class="label">Parameters</span>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td width="20px"></td><td><code><span class="label">value</span>:<a href="../../../int.html">int</a></code> &mdash; The integer value that is treated as a 1-bit value.
+
+	 </td>
+</tr>
+</table>
+<p></p>
+<span class="label">Returns</span>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td width="20"></td><td><code><a href="../../../int.html">int</a></code> &mdash; 
+                  Returns the 32-bit integer value created by sign-extending the 1-bit argument.
+
+	 
+                  
+               </td>
+</tr>
+</table>
+</div>
+<a name="sxi16()"></a>
+<table cellspacing="0" cellpadding="0" class="detailHeader">
+<tr>
+<td class="detailHeaderName">sxi16</td><td class="detailHeaderParens">()</td><td class="detailHeaderType">function</td><td class="detailHeaderRule">&nbsp;</td>
+</tr>
+</table>
+<div class="detailBody">
+<code>public function sxi16(value:<a href="../../../int.html">int</a>):<a href="../../../int.html">int</a></code>
+<p></p>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+	 </td>
+</tr>
+</table>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3.6
+
+	</td>
+</tr>
+</table>
+<p></p><p>
+
+	 Sign-extends a 16-bit integer value to a 32-bit integer value.
+
+	 </p><span class="label">Parameters</span>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td width="20px"></td><td><code><span class="label">value</span>:<a href="../../../int.html">int</a></code> &mdash; The integer value that is treated as a 16-bit value.
+
+	 </td>
+</tr>
+</table>
+<p></p>
+<span class="label">Returns</span>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td width="20"></td><td><code><a href="../../../int.html">int</a></code> &mdash; 
+                  Returns the 32-bit integer value created by sign-extending the 16-bit argument.
+
+	 
+                  
+               </td>
+</tr>
+</table>
+</div>
+<a name="sxi8()"></a>
+<table cellspacing="0" cellpadding="0" class="detailHeader">
+<tr>
+<td class="detailHeaderName">sxi8</td><td class="detailHeaderParens">()</td><td class="detailHeaderType">function</td><td class="detailHeaderRule">&nbsp;</td>
+</tr>
+</table>
+<div class="detailBody">
+<code>public function sxi8(value:<a href="../../../int.html">int</a>):<a href="../../../int.html">int</a></code>
+<p></p>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+	 </td>
+</tr>
+</table>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3.6
+
+	</td>
+</tr>
+</table>
+<p></p><p>
+
+	 Sign-extends an 8-bit integer value to a 32-bit integer value.
+
+	 </p><span class="label">Parameters</span>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td width="20px"></td><td><code><span class="label">value</span>:<a href="../../../int.html">int</a></code> &mdash; The integer value that is treated as an 8-bit value.
+
+	 </td>
+</tr>
+</table>
+<p></p>
+<span class="label">Returns</span>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td width="20"></td><td><code><a href="../../../int.html">int</a></code> &mdash; 
+                  Returns the 32-bit integer value created by sign-extending the 8-bit argument.
+
+	 
+                  
+               </td>
+</tr>
+</table>
+</div>
+<p></p>
+<div class="feedbackLink">
+<center>
+<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Mon Jun 30 2025, 11:00 AM GMT+01:00) : Package avm2.intrinsics.memory">Submit Feedback</a>
+</center>
+</div>
+<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Mon Jun 30 2025, 11:00 AM GMT+01:00<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
+</div>
+</body>
+</html>

--- a/static/reference/actionscript/3.0/compilerErrors.html
+++ b/static/reference/actionscript/3.0/compilerErrors.html
@@ -1056,68 +1056,6 @@ switch(x)
 <tr class="prow1">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1215"></a><b>1215</b></td><td class="summaryTableCol">Invalid initialization: conversion to type _ loses data.</td><td class="summaryTableLastCol">&nbsp;</td>
 </tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1502"></a><b>1502</b></td><td class="summaryTableCol">A script has executed for longer than the default timeout period of 15 seconds.
-		</td><td class="summaryTableLastCol">
-		A script executed after the timeout period. (The default timeout period is 15 seconds.) After this error occurs, the
-		script can continue to execute for 15 seconds more, after which the script terminates and throws run-time error number 1503 (A script failed to exit after 30 seconds and was terminated.)
-		</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1503"></a><b>1503</b></td><td class="summaryTableCol">A script failed to exit after 30 seconds and was terminated.
-		</td><td class="summaryTableLastCol">
-		The script was still executing after 30 seconds. Flash Player first throws run-time error number 1502 (A script has executed for longer than the default timeout period of 15 seconds.) if the script executed more than 15
-		seconds, which is the default timeout period. This error occurs 15 seconds after Error 1502 occurs.
-		</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1507"></a><b>1507</b></td><td class="summaryTableCol">Argument _ cannot be null.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1508"></a><b>1508</b></td><td class="summaryTableCol">The value specified for argument _ is invalid.
-		</td><td class="summaryTableLastCol">
-		You are possibly trying to pass the wrong data type. For example, the code
-		<pre><code>public function doSomething(const:int):void {}
-this ["doSomething"] ("str")</code></pre>
-		generates an error at runtime because <code>doSomething</code> is cast as an int data type.
-		</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1510"></a><b>1510</b></td><td class="summaryTableCol">When the callback argument is a method of a class, the optional this argument must be null.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1511"></a><b>1511</b></td><td class="summaryTableCol">Worker is already started.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1512"></a><b>1512</b></td><td class="summaryTableCol">Starting a worker that already failed is not supported.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1513"></a><b>1513</b></td><td class="summaryTableCol">Worker has terminated."</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1514"></a><b>1514</b></td><td class="summaryTableCol">unlock() with no preceding matching lock().</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1515"></a><b>1515</b></td><td class="summaryTableCol">Invalid condition timeout value: _.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1516"></a><b>1516</b></td><td class="summaryTableCol">Condition cannot notify if associated mutex is not owned.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1517"></a><b>1517</b></td><td class="summaryTableCol">Condition cannot notifyAll if associated mutex is not owned.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1518"></a><b>1518</b></td><td class="summaryTableCol">Condition cannot wait if associated mutex is not owned.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1519"></a><b>1519</b></td><td class="summaryTableCol">Condition cannot be initialized.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1520"></a><b>1520</b></td><td class="summaryTableCol">Mutex cannot be initialized.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1521"></a><b>1521</b></td><td class="summaryTableCol">Only the worker's parent may call start.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
 </table>
 <br>
 <br>
@@ -1125,10 +1063,10 @@ this ["doSomething"] ("str")</code></pre>
 <p></p>
 <div class="feedbackLink">
 <center>
-<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Sat Jan 11 2025, 8:31 AM GMT) : Compiler Errors">Submit Feedback</a>
+<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Mon Jun 30 2025, 11:01 AM GMT+01:00) : Compiler Errors">Submit Feedback</a>
 </center>
 </div>
-<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Sat Jan 11 2025, 8:31 AM GMT<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
+<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Mon Jun 30 2025, 11:01 AM GMT+01:00<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
 </div>
 </div>
 </body>

--- a/static/reference/actionscript/3.0/flash/display/DisplayObject.html
+++ b/static/reference/actionscript/3.0/flash/display/DisplayObject.html
@@ -52,7 +52,8 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0 </td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+ </td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
@@ -62,42 +63,82 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 </table>
 <p></p>
 <p></p>
+
  The DisplayObject class is the base class for all objects that can be placed on 
+
  the display list. The display list manages all objects displayed in the Flash runtimes. 
+
  Use the DisplayObjectContainer class to arrange the display objects in the display list.
+
  DisplayObjectContainer objects can have child display objects, while other display objects, such as
+
  Shape and TextField objects, are "leaf" nodes that have only parents and siblings, no children. 
-  <p>The DisplayObject class supports basic functionality like the <i>x</i> and <i>y</i> position of 
+
+ 
+ <p>The DisplayObject class supports basic functionality like the <i>x</i> and <i>y</i> position of 
+
  an object, as well as more advanced properties of the object such as its transformation matrix. 
+
  </p>
-  <p>DisplayObject is an abstract base class; therefore, you cannot call DisplayObject directly. Invoking
+
+ 
+ <p>DisplayObject is an abstract base class; therefore, you cannot call DisplayObject directly. Invoking
+
  <code>new DisplayObject()</code> throws an <code>ArgumentError</code> exception. </p>
+
  
+
  <p>All display objects inherit from the DisplayObject class.</p>
+
  
+
  <p>The DisplayObject class itself does not include any APIs for rendering content onscreen. 
+
  For that reason, if you want create a custom subclass of the DisplayObject class, you will want
+
  to extend one of its subclasses that do have APIs for rendering content onscreen, 
+
  such as the Shape, Sprite, Bitmap, SimpleButton, TextField, or MovieClip class.</p>
+
  
+
  <p>The DisplayObject class contains several broadcast events. Normally, the target
+
  of any particular event is a specific DisplayObject instance. For example,
+
  the target of an <code>added</code> event is the specific DisplayObject instance
+
  that was added to the display list. Having a single target restricts the placement of
+
  event listeners to that target and in some cases the target's ancestors on the display list.
+
  With broadcast events, however, the target is not a specific DisplayObject instance,
+
  but rather all DisplayObject instances, including those that are not on the display list.
+
  This means that you can add a listener to any DisplayObject instance to listen for broadcast events.
+
  In addition to the broadcast events listed in the DisplayObject class's Events table,
+
  the DisplayObject class also inherits two broadcast events from the EventDispatcher
+
  class: <code>activate</code> and <code>deactivate</code>.</p>
-  <p>Some properties previously used in the ActionScript 1.0 and 2.0 MovieClip, TextField, and Button
- classes (such as <code>_alpha</code>, <code>_height</code>, <code>_name</code>, <code>_width</code>,
- <code>_x</code>, <code>_y</code>, and others) have equivalents in the ActionScript 3.0
- DisplayObject class that are renamed so that they no longer begin with the underscore (_) character.</p>
+
  
+ <p>Some properties previously used in the ActionScript 1.0 and 2.0 MovieClip, TextField, and Button
+
+ classes (such as <code>_alpha</code>, <code>_height</code>, <code>_name</code>, <code>_width</code>,
+
+ <code>_x</code>, <code>_y</code>, and others) have equivalents in the ActionScript 3.0
+
+ DisplayObject class that are renamed so that they no longer begin with the underscore (_) character.</p>
+
+ 
+
  <p>For more information, see the "Display Programming" chapter of the <em>ActionScript 3.0 Developer's Guide</em>.</p>
-  <p></p>
+
+ 
+ <p></p>
 <p>
 <a href="#includeExamplesSummary">View the examples.</a>
 </p>
@@ -128,38 +169,46 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <tr class="">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol"><a class="signatureLink" href="#accessibilityProperties">accessibilityProperties</a> : <a href="../accessibility/AccessibilityProperties.html">AccessibilityProperties</a>
 <div class="summaryTableDescription">
+
      The current accessibility options for this display object.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol"><a class="signatureLink" href="#alpha">alpha</a> : <a href="../../Number.html">Number</a>
 <div class="summaryTableDescription">
+
      Indicates the alpha transparency value of the object specified.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol"><a class="signatureLink" href="#blendMode">blendMode</a> : <a href="../../String.html">String</a>
 <div class="summaryTableDescription">
+
      A value from the BlendMode class that specifies which blend mode to use.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol"><a class="signatureLink" href="#blendShader">blendShader</a> : <a href="../display/Shader.html">Shader</a>
 <div class="summaryTableDescription">[write-only]
+
      Sets a shader that is used for blending the foreground and background.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol"><a class="signatureLink" href="#cacheAsBitmap">cacheAsBitmap</a> : <a href="../../Boolean.html">Boolean</a>
 <div class="summaryTableDescription">
+
      If set to <code>true</code>, Flash runtimes cache an internal bitmap representation of the
+
      display object.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol"><a class="signatureLink" href="#cacheAsBitmapMatrix">cacheAsBitmapMatrix</a> : <a href="../geom/Matrix.html">Matrix</a>
 <div class="summaryTableDescription">
+
      If non-null, this Matrix object defines how a display object is rendered when 
+
      <code>cacheAsBitmap</code> is set to <code>true</code>.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
@@ -173,62 +222,74 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <tr class="">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol"><a class="signatureLink" href="#filters">filters</a> : <a href="../../Array.html">Array</a>
 <div class="summaryTableDescription">
+
      An indexed array that contains each filter object currently associated with the display object.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol"><a class="signatureLink" href="#height">height</a> : <a href="../../Number.html">Number</a>
 <div class="summaryTableDescription">
+
      Indicates the height of the display object, in pixels.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol"><a class="signatureLink" href="#loaderInfo">loaderInfo</a> : <a href="../display/LoaderInfo.html">LoaderInfo</a>
 <div class="summaryTableDescription">[read-only]
+
      Returns a LoaderInfo object containing information about loading the file
+
      to which this display object belongs.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol"><a class="signatureLink" href="#mask">mask</a> : <a href="../display/DisplayObject.html">DisplayObject</a>
 <div class="summaryTableDescription">
+
      The calling display object is masked by the specified <code>mask</code> object.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol"><a class="signatureLink" href="#metaData">metaData</a> : <a href="../../Object.html">Object</a>
 <div class="summaryTableDescription">
+
      Obtains the meta data object of the DisplayObject instance if meta data was stored alongside the
+
      the instance of this DisplayObject in the SWF file through a PlaceObject4 tag.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol"><a class="signatureLink" href="#mouseX">mouseX</a> : <a href="../../Number.html">Number</a>
 <div class="summaryTableDescription">[read-only]
+
      Indicates the x coordinate of the mouse or user input device position, in pixels.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol"><a class="signatureLink" href="#mouseY">mouseY</a> : <a href="../../Number.html">Number</a>
 <div class="summaryTableDescription">[read-only]
+
      Indicates the y coordinate of the mouse or user input device position, in pixels.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol"><a class="signatureLink" href="#name">name</a> : <a href="../../String.html">String</a>
 <div class="summaryTableDescription">
+
      Indicates the instance name of the DisplayObject.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol"><a class="signatureLink" href="#opaqueBackground">opaqueBackground</a> : <a href="../../Object.html">Object</a>
 <div class="summaryTableDescription">
+
      Specifies whether the display object is opaque with a certain background color.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol"><a class="signatureLink" href="#parent">parent</a> : <a href="../display/DisplayObjectContainer.html">DisplayObjectContainer</a>
 <div class="summaryTableDescription">[read-only]
+
      Indicates the DisplayObjectContainer object that contains this display object.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
@@ -242,106 +303,127 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <tr class="">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol"><a class="signatureLink" href="#root">root</a> : <a href="../display/DisplayObject.html">DisplayObject</a>
 <div class="summaryTableDescription">[read-only]
+
      For a display object in a loaded SWF file, the <code>root</code> property is the 
+
      top-most display object in the portion of the display list's tree structure represented by that SWF file.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol"><a class="signatureLink" href="#rotation">rotation</a> : <a href="../../Number.html">Number</a>
 <div class="summaryTableDescription">
+
      Indicates the rotation of the DisplayObject instance, in degrees, from its original orientation.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol"><a class="signatureLink" href="#rotationX">rotationX</a> : <a href="../../Number.html">Number</a>
 <div class="summaryTableDescription">
+
      Indicates the x-axis rotation of the DisplayObject instance, in degrees, from its original orientation relative to the 3D parent container.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol"><a class="signatureLink" href="#rotationY">rotationY</a> : <a href="../../Number.html">Number</a>
 <div class="summaryTableDescription">
+
      Indicates the y-axis rotation of the DisplayObject instance, in degrees, from its original orientation relative to the 3D parent container.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol"><a class="signatureLink" href="#rotationZ">rotationZ</a> : <a href="../../Number.html">Number</a>
 <div class="summaryTableDescription">
+
      Indicates the z-axis rotation of the DisplayObject instance, in degrees, from its original orientation relative to the 3D parent container.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol"><a class="signatureLink" href="#scale9Grid">scale9Grid</a> : <a href="../geom/Rectangle.html">Rectangle</a>
 <div class="summaryTableDescription">
+
      The current scaling grid that is in effect.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol"><a class="signatureLink" href="#scaleX">scaleX</a> : <a href="../../Number.html">Number</a>
 <div class="summaryTableDescription">
+
      Indicates the horizontal scale (percentage) of the object as applied from the registration point.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol"><a class="signatureLink" href="#scaleY">scaleY</a> : <a href="../../Number.html">Number</a>
 <div class="summaryTableDescription">
+
      Indicates the vertical scale (percentage) of an object as applied from the registration point of the object.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol"><a class="signatureLink" href="#scaleZ">scaleZ</a> : <a href="../../Number.html">Number</a>
 <div class="summaryTableDescription">
+
      Indicates the depth scale (percentage) of an object as applied from the registration point of the object.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol"><a class="signatureLink" href="#scrollRect">scrollRect</a> : <a href="../geom/Rectangle.html">Rectangle</a>
 <div class="summaryTableDescription">
+
      The scroll rectangle bounds of the display object.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol"><a class="signatureLink" href="#stage">stage</a> : <a href="../display/Stage.html">Stage</a>
 <div class="summaryTableDescription">[read-only]
+
      The Stage of the display object.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol"><a class="signatureLink" href="#transform">transform</a> : <a href="../geom/Transform.html">Transform</a>
 <div class="summaryTableDescription">
+
     An object with properties pertaining to a display object's matrix, color transform, and pixel bounds.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol"><a class="signatureLink" href="#visible">visible</a> : <a href="../../Boolean.html">Boolean</a>
 <div class="summaryTableDescription">
+
      Whether or not the display object is visible.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol"><a class="signatureLink" href="#width">width</a> : <a href="../../Number.html">Number</a>
 <div class="summaryTableDescription">
+
      Indicates the width of the display object, in pixels.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol"><a class="signatureLink" href="#x">x</a> : <a href="../../Number.html">Number</a>
 <div class="summaryTableDescription">
+
      Indicates the <i>x</i> coordinate of the DisplayObject instance relative to the local coordinates of
+
      the parent DisplayObjectContainer.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol"><a class="signatureLink" href="#y">y</a> : <a href="../../Number.html">Number</a>
 <div class="summaryTableDescription">
+
      Indicates the <i>y</i> coordinate of the DisplayObject instance relative to the local coordinates of
+
      the parent DisplayObjectContainer.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol"><a class="signatureLink" href="#z">z</a> : <a href="../../Number.html">Number</a>
 <div class="summaryTableDescription">
+
      Indicates the z coordinate position along the z-axis of the DisplayObject
+
      instance relative to the 3D parent container.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
@@ -387,7 +469,9 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="#getBounds()">getBounds</a>(targetCoordinateSpace:<a href="DisplayObject.html">DisplayObject</a>):<a href="../geom/Rectangle.html">Rectangle</a>
 </div>
 <div class="summaryTableDescription">
+
      Returns a rectangle that defines the area of the display object relative to the coordinate system
+
      of the <code>targetCoordinateSpace</code> object.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
@@ -397,8 +481,11 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="#getRect()">getRect</a>(targetCoordinateSpace:<a href="DisplayObject.html">DisplayObject</a>):<a href="../geom/Rectangle.html">Rectangle</a>
 </div>
 <div class="summaryTableDescription">
+
     Returns a rectangle that defines the boundary of the display object, 
+
     based on the coordinate system defined by the <code>targetCoordinateSpace</code> 
+
     parameter, excluding any strokes on shapes.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
@@ -408,7 +495,9 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="#globalToLocal()">globalToLocal</a>(point:<a href="../geom/Point.html">Point</a>):<a href="../geom/Point.html">Point</a>
 </div>
 <div class="summaryTableDescription">
+
      Converts the <code>point</code> object from the Stage (global) coordinates
+
      to the display object's (local) coordinates.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
@@ -418,7 +507,9 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="#globalToLocal3D()">globalToLocal3D</a>(point:<a href="../geom/Point.html">Point</a>):<a href="../geom/Vector3D.html">Vector3D</a>
 </div>
 <div class="summaryTableDescription">
+
      Converts a two-dimensional point from the Stage (global) coordinates to a
+
      three-dimensional display object's (local) coordinates.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
@@ -448,7 +539,9 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="#hitTestObject()">hitTestObject</a>(obj:<a href="DisplayObject.html">DisplayObject</a>):<a href="../../Boolean.html">Boolean</a>
 </div>
 <div class="summaryTableDescription">
+
      Evaluates the bounding box of the display object to see if it overlaps or intersects with the
+
      bounding box of the <code>obj</code> display object.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
@@ -458,7 +551,9 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="#hitTestPoint()">hitTestPoint</a>(x:<a href="../../Number.html">Number</a>, y:<a href="../../Number.html">Number</a>, shapeFlag:<a href="../../Boolean.html">Boolean</a> = false):<a href="../../Boolean.html">Boolean</a>
 </div>
 <div class="summaryTableDescription">
+
      Evaluates the display object to see if it overlaps or intersects with the
+
      point specified by the <code>x</code> and <code>y</code> parameters.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
@@ -480,7 +575,9 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="#local3DToGlobal()">local3DToGlobal</a>(point3d:<a href="../geom/Vector3D.html">Vector3D</a>):<a href="../geom/Point.html">Point</a>
 </div>
 <div class="summaryTableDescription">
+
      Converts a three-dimensional point of the three-dimensional display 
+
      object's (local) coordinates to a two-dimensional point in the Stage (global) coordinates.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
@@ -490,7 +587,9 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="#localToGlobal()">localToGlobal</a>(point:<a href="../geom/Point.html">Point</a>):<a href="../geom/Point.html">Point</a>
 </div>
 <div class="summaryTableDescription">
+
      Converts the <code>point</code> object from the display object's (local) coordinates to the
+
      Stage (global) coordinates.</div>
 </td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
@@ -595,6 +694,7 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="#event:added">added</a>
 </div>
 </td><td class="summaryTableDescription summaryTableCol">
+
  Dispatched when a display object is added to the display list.</td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="">
@@ -603,7 +703,9 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="#event:addedToStage">addedToStage</a>
 </div>
 </td><td class="summaryTableDescription summaryTableCol">
+
  Dispatched when a display object is added to the on stage display list, 
+
  either directly or through the addition of a sub tree in which the display object is contained.</td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="hideInheritedEvent">
@@ -621,7 +723,9 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="#event:enterFrame">enterFrame</a>
 </div>
 </td><td class="summaryTableDescription summaryTableCol">
+
  [broadcast event] Dispatched when the playhead is entering a new 
+
  frame.</td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="">
@@ -630,6 +734,7 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="#event:exitFrame">exitFrame</a>
 </div>
 </td><td class="summaryTableDescription summaryTableCol">
+
  [broadcast event] Dispatched when the playhead is exiting the current frame.</td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="">
@@ -638,6 +743,7 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="#event:frameConstructed">frameConstructed</a>
 </div>
 </td><td class="summaryTableDescription summaryTableCol">
+
  [broadcast event] Dispatched after the constructors of frame display objects have run but before frame scripts have run.</td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="">
@@ -646,6 +752,7 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="#event:removed">removed</a>
 </div>
 </td><td class="summaryTableDescription summaryTableCol">
+
  Dispatched when a display object is about to be removed from the display list.</td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="">
@@ -654,7 +761,9 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="#event:removedFromStage">removedFromStage</a>
 </div>
 </td><td class="summaryTableDescription summaryTableCol">
+
  Dispatched when a display object is about to be removed from the display list, 
+
  either directly or through the removal of a sub tree in which the display object is contained.</td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 <tr class="">
@@ -663,6 +772,7 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="#event:render">render</a>
 </div>
 </td><td class="summaryTableDescription summaryTableCol">
+
  [broadcast event] Dispatched when the display list is about to be updated and rendered.</td><td class="summaryTableOwnerCol">DisplayObject</td>
 </tr>
 </table>
@@ -684,7 +794,10 @@ showHideInherited();
 <code>accessibilityProperties:<a href="../accessibility/AccessibilityProperties.html">AccessibilityProperties</a></code>&nbsp;&nbsp;[read-write]<p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0           
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     
+      
+
      </td>
 </tr>
 </table>
@@ -694,13 +807,22 @@ showHideInherited();
 </tr>
 </table>
 <p></p><p>
+
      The current accessibility options for this display object. If you modify the <code>accessibilityProperties</code>
+
      property or any of the fields within <code>accessibilityProperties</code>, you must call 
+
      the <code>Accessibility.updateProperties()</code> method to make your changes take effect.
-          <p class="flashonly"><strong>Note</strong>: For an object created in the Flash authoring environment, the value of <code>accessibilityProperties</code>
+
+     
+     <p class="flashonly"><strong>Note</strong>: For an object created in the Flash authoring environment, the value of <code>accessibilityProperties</code>
+
      is prepopulated with any information you entered in the Accessibility panel for
+
      that object.</p>
-          </p><span class="label">Implementation</span>
+
+     
+     </p><span class="label">Implementation</span>
 <br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;public function get accessibilityProperties():<a href="../accessibility/AccessibilityProperties.html">AccessibilityProperties</a></code>
 <br>
@@ -752,7 +874,10 @@ trace(tf.accessibilityProperties.name); // Greeting</pre>
 <code>alpha:<a href="../../Number.html">Number</a></code>&nbsp;&nbsp;[read-write]<p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0           
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     
+      
+
       </td>
 </tr>
 </table>
@@ -762,11 +887,17 @@ trace(tf.accessibilityProperties.name); // Greeting</pre>
 </tr>
 </table>
 <p></p><p>
+
      Indicates the alpha transparency value of the object specified.
+
      Valid values are 0 (fully transparent) to 1 (fully opaque).
+
      The default value is 1. Display objects with <code>alpha</code>
+
      set to 0 <em>are</em> active, even though they are invisible.
-          </p><span class="label">Implementation</span>
+
+     
+     </p><span class="label">Implementation</span>
 <br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;public function get alpha():<a href="../../Number.html">Number</a></code>
 <br>
@@ -809,7 +940,9 @@ function restoreObject(event:MouseEvent):void {
 <code>blendMode:<a href="../../String.html">String</a></code>&nbsp;&nbsp;[read-write]<p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0      
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+      
+
      </td>
 </tr>
 </table>
@@ -819,170 +952,387 @@ function restoreObject(event:MouseEvent):void {
 </tr>
 </table>
 <p></p><p>
+
      A value from the BlendMode class that specifies which blend mode to use.
+
      A bitmap can be drawn internally in two ways. If you have a blend mode enabled or an
+
      external clipping mask, the bitmap is drawn by adding a bitmap-filled square shape to the vector
+
      render. If you attempt to set this property to an invalid value, Flash runtimes set the value
+
      to <code>BlendMode.NORMAL</code>.
-          </p><p>The <code>blendMode</code> property affects each pixel of the display object.
+
+     
+     </p><p>The <code>blendMode</code> property affects each pixel of the display object.
+
      Each pixel is composed of three constituent
+
      colors (red, green, and blue), and each constituent color has a value between 0x00 and 0xFF.
+
      Flash Player or Adobe AIR compares each constituent color of one pixel in the movie clip with
+
      the corresponding color of the pixel in the background. For example, if <code>blendMode</code>
+
      is set to <code>BlendMode.LIGHTEN</code>, Flash Player or Adobe AIR compares the red value of the display object with
+
      the red value of the background, and uses the lighter of the two as the
+
      value for the red component of the displayed color.</p>
-          <p>The following table describes the <code>blendMode</code> settings. 
+
+     
+     <p>The following table describes the <code>blendMode</code> settings. 
+
      The BlendMode class defines string values you can use.
+
      The illustrations in the table show <code>blendMode</code> values applied to a circular
+
      display object (2) superimposed on another display object (1).</p>
-               <p>
+
+     
+     
+     <p>
+
       <img src="../../images/blendMode-0a.jpg" alt="Square Number 1" />
-           <img src="../../images/blendMode-0b.jpg" alt="Circle Number 2" />
-          </p>
-               <table class="innertable">
-          <tr valign="top">
-          <th>BlendMode Constant</th>
+
+     
+      <img src="../../images/blendMode-0b.jpg" alt="Circle Number 2" />
+
+     
+     </p>
+
+     
+     
+     <table class="innertable">
+
+     
+     <tr valign="top">
+
+     
+     <th>BlendMode Constant</th>
+
      <th>Illustration</th>
+
      <th>Description</th>
+
      </tr>
-          <tr valign="top">
+
+     
+     <tr valign="top">
+
      <td><code>BlendMode.NORMAL</code></td>
+
      <td><img src="../../images/blendMode-1.jpg" alt="blend mode NORMAL" /></td>
+
      <td>The display object appears in front of the background. Pixel values of the display object
+
      override those of the background. Where the display object is transparent, the background is
+
      visible.</td>
+
      </tr>
-          <tr valign="top">
+
+     
+     <tr valign="top">
+
      <td><code>BlendMode.LAYER</code></td>
+
      <td><img src="../../images/blendMode-2.jpg" alt="blend mode LAYER" /></td>
-          <td>Forces the creation of a transparency group for the display object. This means that the display 
+
+     
+     <td>Forces the creation of a transparency group for the display object. This means that the display 
+
      object is pre-composed in a temporary buffer before it is processed further. This is done 
+
      automatically if the display object is pre-cached using bitmap caching or if the display object is 
+
      a display object container with at least one child object with a <code>blendMode</code> 
+
      setting other than <code>BlendMode.NORMAL</code>. Not supported under GPU rendering.
+
      </td>
+
      </tr>
-          <tr valign="top">
+
+     
+     <tr valign="top">
+
      <td><code>BlendMode.MULTIPLY</code></td>
+
      <td><img src="../../images/blendMode-3.jpg" alt="blend mode MULTIPLY" /></td>
-          <td>Multiplies the values of the display object constituent colors by the colors of the background color,
+
+     
+     <td>Multiplies the values of the display object constituent colors by the colors of the background color,
+
      and then normalizes by dividing by 0xFF,
+
      resulting in darker colors. This setting is commonly used for shadows and depth effects.
-          <p>For example, if a constituent color (such as red) of one pixel in the display object and the
+
+     
+     <p>For example, if a constituent color (such as red) of one pixel in the display object and the
+
      corresponding color of the pixel in the background both have the value 0x88, the multiplied
+
      result is 0x4840. Dividing by 0xFF yields a value of 0x48 for that constituent color,
+
      which is a darker shade than the color of the display object or the color of the background.</p></td>
+
      </tr>
-          <tr valign="top">
+
+     
+     <tr valign="top">
+
      <td><code>BlendMode.SCREEN</code></td>
+
      <td><img src="../../images/blendMode-4.jpg" alt="blend mode SCREEN" /></td>
-          <td>Multiplies the complement (inverse) of the display object color by the complement of the background
+
+     
+     <td>Multiplies the complement (inverse) of the display object color by the complement of the background
+
      color, resulting in a bleaching effect. This setting is commonly used for highlights or to remove black
+
      areas of the display object.</td>
+
      </tr>
-          <tr valign="top">
+
+     
+     <tr valign="top">
+
      <td><code>BlendMode.LIGHTEN</code></td>
+
      <td><img src="../../images/blendMode-5.jpg" alt="blend mode LIGHTEN" /></td>
-          <td>Selects the lighter of the constituent colors of the display object and the color of the background (the
+
+     
+     <td>Selects the lighter of the constituent colors of the display object and the color of the background (the
+
      colors with the larger values). This setting is commonly used for superimposing type.
-          <p>For example, if the display object has a pixel with an RGB value of 0xFFCC33, and the background
+
+     
+     <p>For example, if the display object has a pixel with an RGB value of 0xFFCC33, and the background
+
      pixel has an RGB value of 0xDDF800, the resulting RGB value for the displayed pixel is
+
      0xFFF833 (because 0xFF > 0xDD, 0xCC &lt; 0xF8, and 0x33 > 0x00 = 33). Not supported under GPU rendering.</p></td>
-          </tr>
-          <tr valign="top">
+
+     
+     </tr>
+
+     
+     <tr valign="top">
+
      <td><code>BlendMode.DARKEN</code></td>
+
      <td><img src="../../images/blendMode-6.jpg" alt="blend mode DARKEN" /></td>
-          <td>Selects the darker of the constituent colors of the display object and the colors of the 
+
+     
+     <td>Selects the darker of the constituent colors of the display object and the colors of the 
+
      background (the colors with the smaller values). This setting is commonly used for superimposing type.
-          <p>For example, if the display object has a pixel with an RGB value of 0xFFCC33, and the background
+
+     
+     <p>For example, if the display object has a pixel with an RGB value of 0xFFCC33, and the background
+
      pixel has an RGB value of 0xDDF800, the resulting RGB value for the displayed pixel is
+
      0xDDCC00 (because 0xFF > 0xDD, 0xCC &lt; 0xF8, and 0x33 > 0x00 = 33). Not supported under GPU rendering.</p></td>
-          </tr>
-          <tr valign="top">
+
+     
+     </tr>
+
+     
+     <tr valign="top">
+
      <td><code>BlendMode.DIFFERENCE</code></td>
+
      <td><img src="../../images/blendMode-7.jpg" alt="blend mode DIFFERENCE" /></td>
-          <td>Compares the constituent colors of the display object with the colors of its background, and subtracts
+
+     
+     <td>Compares the constituent colors of the display object with the colors of its background, and subtracts
+
      the darker of the values of the two constituent colors from the lighter value. This setting is commonly
+
      used for more vibrant colors.
-          <p>For example, if the display object has a pixel with an RGB value of 0xFFCC33, and the background
+
+     
+     <p>For example, if the display object has a pixel with an RGB value of 0xFFCC33, and the background
+
      pixel has an RGB value of 0xDDF800, the resulting RGB value for the displayed pixel is
+
      0x222C33 (because 0xFF - 0xDD = 0x22, 0xF8 - 0xCC = 0x2C, and 0x33 - 0x00 = 0x33).</p></td>
+
      </tr>
-          <tr valign="top">
+
+     
+     <tr valign="top">
+
      <td><code>BlendMode.ADD</code></td>
+
      <td><img src="../../images/blendMode-8.jpg" alt="blend mode ADD" /></td>
-          <td>Adds the values of the constituent colors of the display object to the colors of its background, applying a
+
+     
+     <td>Adds the values of the constituent colors of the display object to the colors of its background, applying a
+
      ceiling of 0xFF. This setting is commonly used for animating a lightening dissolve between
+
      two objects.
-          <p>For example, if the display object has a pixel with an RGB value of 0xAAA633, and the background
+
+     
+     <p>For example, if the display object has a pixel with an RGB value of 0xAAA633, and the background
+
      pixel has an RGB value of 0xDD2200, the resulting RGB value for the displayed pixel is
+
      0xFFC833 (because 0xAA + 0xDD > 0xFF, 0xA6 + 0x22 = 0xC8, and 0x33 + 0x00 = 0x33).</p></td>
-          </tr>
-          <tr valign="top">
+
+     
+     </tr>
+
+     
+     <tr valign="top">
+
      <td><code>BlendMode.SUBTRACT</code></td>
+
      <td><img src="../../images/blendMode-9.jpg" alt="blend mode SUBTRACT" /></td>
-          <td>Subtracts the values of the constituent colors in the display object from the values of the 
+
+     
+     <td>Subtracts the values of the constituent colors in the display object from the values of the 
+
      background color, applying a floor of 0. This setting is commonly used for animating a 
+
      darkening dissolve between two objects.
-          <p>For example, if the display object has a pixel with an RGB value of 0xAA2233, and the background
+
+     
+     <p>For example, if the display object has a pixel with an RGB value of 0xAA2233, and the background
+
      pixel has an RGB value of 0xDDA600, the resulting RGB value for the displayed pixel is
+
      0x338400 (because 0xDD - 0xAA = 0x33, 0xA6 - 0x22 = 0x84, and 0x00 - 0x33 &lt; 0x00).</p></td>
+
      </tr>
-               <tr valign="top">
+
+     
+     
+     <tr valign="top">
+
      <td><code>BlendMode.INVERT</code></td>
+
      <td><img src="../../images/blendMode-10.jpg" alt="blend mode INVERT" /></td>
-          <td>Inverts the background.</td>
+
+     
+     <td>Inverts the background.</td>
+
      </tr>
-               <tr valign="top">
+
+     
+     
+     <tr valign="top">
+
      <td><code>BlendMode.ALPHA</code></td>
+
      <td><img src="../../images/blendMode-11.jpg" alt="blend mode ALPHA" /></td>
-          <td>Applies the alpha value of each pixel of the display object to the background.
+
+     
+     <td>Applies the alpha value of each pixel of the display object to the background.
+
      This requires the <code>blendMode</code> setting of the parent display object to be set to
+
      <code>BlendMode.LAYER</code>.
+
      For example, in the illustration, the parent display object, which is a white background,
+
      has <code>blendMode = BlendMode.LAYER</code>. Not supported under GPU rendering.</td>
+
      </tr>
-          <tr valign="top">
+
+     
+     <tr valign="top">
+
      <td><code>BlendMode.ERASE</code></td>
+
      <td><img src="../../images/blendMode-12.jpg" alt="blend mode ERASE" /></td>
-          <td>Erases the background based on the alpha value of the display object. This requires the
+
+     
+     <td>Erases the background based on the alpha value of the display object. This requires the
+
      <code>blendMode</code> of the parent display object to be set to
+
      <code>BlendMode.LAYER</code>. For example, in the
+
      illustration, the parent display object, which is a white background, has
+
      <code>blendMode = BlendMode.LAYER</code>. Not supported under GPU rendering.</td>
+
      </tr>
-               <tr valign="top">
+
+     
+     
+     <tr valign="top">
+
      <td><code>BlendMode.OVERLAY</code></td>
+
      <td><img src="../../images/blendMode-13.jpg" alt="blend mode OVERLAY" /></td>
-          <td>Adjusts the color of each pixel based on the darkness of the background.
+
+     
+     <td>Adjusts the color of each pixel based on the darkness of the background.
+
      If the background is lighter than 50% gray, the display object and background colors are
+
      screened, which results in a lighter color. If the background is darker than 50% gray,
+
      the colors are multiplied, which results in a darker color.
+
      This setting is commonly used for shading effects. Not supported under GPU rendering.</td>
+
      </tr>
-          <tr valign="top">
+
+     
+     <tr valign="top">
+
      <td><code>BlendMode.HARDLIGHT</code></td>
+
      <td><img src="../../images/blendMode-14.jpg" alt="blend mode HARDLIGHT" /></td>
-          <td>Adjusts the color of each pixel based on the darkness of the display object.
+
+     
+     <td>Adjusts the color of each pixel based on the darkness of the display object.
+
      If the display object is lighter than 50% gray, the display object and background colors are
+
      screened, which results in a lighter color. If the display object is darker than 50% gray,
+
      the colors are multiplied, which results in a darker color.
+
      This setting is commonly used for shading effects. Not supported under GPU rendering.</td>
+
      </tr>
-          <tr valign="top">
+
+     
+     <tr valign="top">
+
      <td><code>BlendMode.SHADER</code></td>
+
      <td align="center" valign="middle">N/A</td>
-          <td>Adjusts the color using a custom shader routine. The shader that is used is specified 
+
+     
+     <td>Adjusts the color using a custom shader routine. The shader that is used is specified 
+
      as the Shader instance assigned to the <code>blendShader</code> property. Setting the 
+
      <code>blendShader</code> property of a display object to a Shader instance 
+
      automatically sets the display object's <code>blendMode</code> property to 
+
      <code>BlendMode.SHADER</code>. If the <code>blendMode</code> property is set to 
+
      <code>BlendMode.SHADER</code> without first setting the <code>blendShader</code> property,
+
      the <code>blendMode</code> property is set to <code>BlendMode.NORMAL</code>. Not supported under GPU rendering.</td>
+
      </tr>
-          </table>
-          <span class="label">Implementation</span>
+
+     
+     </table>
+
+     
+     <span class="label">Implementation</span>
 <br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;public function get blendMode():<a href="../../String.html">String</a></code>
 <br>
@@ -1040,43 +1390,74 @@ function restoreObject(event:MouseEvent):void {
 <code>blendShader:<a href="../display/Shader.html">Shader</a></code>&nbsp;&nbsp;[write-only]<p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0      
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+      
+
      </td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;1.5
+
 </td>
 </tr>
 </table>
 <p></p><p>
+
      Sets a shader that is used for blending the foreground and background. When the 
+
      <code>blendMode</code> property is set to <code>BlendMode.SHADER</code>, the specified 
+
      Shader is used to create the blend mode output for the display object.
+
      
+
      </p><p>Setting the <code>blendShader</code> property of a display object to a Shader instance 
+
      automatically sets the display object's <code>blendMode</code> property to 
+
      <code>BlendMode.SHADER</code>. If the <code>blendShader</code> property is set (which sets the 
+
      <code>blendMode</code> property to <code>BlendMode.SHADER</code>), then the value of the 
+
      <code>blendMode</code> property is changed, the blend mode can be reset to use the blend 
+
      shader simply by setting the <code>blendMode</code> property to <code>BlendMode.SHADER</code>. 
+
      The <code>blendShader</code> property does not need to be set again except to change the 
+
      shader that's used for the blend mode.</p>
+
      
+
      <p>The Shader assigned to the <code>blendShader</code> property must specify at least two 
+
      <code>image4</code> inputs. The inputs <b>do not</b> need to be specified in code using the 
+
      associated ShaderInput objects' <code>input</code> properties. The background display object 
+
      is automatically 
+
      used as the first input (the input with <code>index</code> 0). The foreground display object 
+
      is used as the second input (the input with <code>index</code> 1). A shader used as a blend 
+
      shader can specify more than two inputs. In that case, any additional input must be specified 
+
      by setting its ShaderInput instance's <code>input</code> property.</p>
-          <p>When you assign a Shader instance to this property the shader is copied internally. The 
-     blend operation uses that internal copy, not a reference to the original shader. Any changes 
-     made to the shader, such as changing a parameter value, input, or bytecode, are not applied 
-     to the copied shader that's used for the blend mode.</p>
+
      
+     <p>When you assign a Shader instance to this property the shader is copied internally. The 
+
+     blend operation uses that internal copy, not a reference to the original shader. Any changes 
+
+     made to the shader, such as changing a parameter value, input, or bytecode, are not applied 
+
+     to the copied shader that's used for the blend mode.</p>
+
+     
+
      <span class="label">Implementation</span>
 <br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;public function set blendShader(value:<a href="../display/Shader.html">Shader</a>):<a href="../../specialTypes.html#void">void</a></code>
@@ -1087,9 +1468,13 @@ function restoreObject(event:MouseEvent):void {
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20"></td><td><code><a href="../../ArgumentError.html">ArgumentError</a> </code> &mdash; When the shader output type is not compatible with this operation 
+
                            (the shader must specify a <code>pixel4</code> 
+
                            output).
+
      
+
      </td>
 </tr>
 <tr>
@@ -1097,8 +1482,11 @@ function restoreObject(event:MouseEvent):void {
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../ArgumentError.html">ArgumentError</a> </code> &mdash; When the shader specifies fewer than two image inputs or the first
+
                            two inputs are not <code>image4</code> inputs.
+
      
+
      </td>
 </tr>
 <tr>
@@ -1106,7 +1494,9 @@ function restoreObject(event:MouseEvent):void {
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../ArgumentError.html">ArgumentError</a> </code> &mdash; When the shader specifies an image input that isn't provided.
+
      
+
      </td>
 </tr>
 <tr>
@@ -1114,12 +1504,19 @@ function restoreObject(event:MouseEvent):void {
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../ArgumentError.html">ArgumentError</a> </code> &mdash; When a ByteArray or Vector.&lt;Number&gt; instance is used as 
+
                            an input and the <code>width</code> 
+
                            and <code>height</code> properties aren't specified for the 
+
                            ShaderInput, or the specified values don't match the amount of 
+
                            data in the input object. See the <code>ShaderInput.input</code> 
+
                            property for more information.
+
      
+
      </td>
 </tr>
 </table>
@@ -1144,7 +1541,9 @@ function restoreObject(event:MouseEvent):void {
 <code>cacheAsBitmap:<a href="../../Boolean.html">Boolean</a></code>&nbsp;&nbsp;[read-write]<p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0          </td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     
+     </td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
@@ -1153,46 +1552,98 @@ function restoreObject(event:MouseEvent):void {
 </tr>
 </table>
 <p></p><p>
+
      If set to <code>true</code>, Flash runtimes cache an internal bitmap representation of the
+
      display object. This caching can increase performance for display objects that contain complex
+
      vector content.
-          </p><p>All vector data for a display object that has a cached bitmap is drawn to the bitmap
+
+     
+     </p><p>All vector data for a display object that has a cached bitmap is drawn to the bitmap
+
      instead of the main display. If <code>cacheAsBitmapMatrix</code> is null or unsupported,
+
 	 the bitmap is then copied to the main display as unstretched, unrotated pixels snapped to
+
 	 the nearest pixel boundaries. Pixels are mapped 1 to 1 with
+
      the parent object. If the bounds of the bitmap change, the bitmap is recreated instead
+
      of being stretched.</p>
-	 	 <p>If <code>cacheAsBitmapMatrix</code> is non-null and supported, the object is drawn to the off-screen bitmap
+
+	 
+	 <p>If <code>cacheAsBitmapMatrix</code> is non-null and supported, the object is drawn to the off-screen bitmap
+
 	 using that matrix and the stretched and/or rotated results of that rendering are used
+
 	 to draw the object to the main display.</p>
-          <p>No internal bitmap is created unless the <code>cacheAsBitmap</code> property is set to
+
+     
+     <p>No internal bitmap is created unless the <code>cacheAsBitmap</code> property is set to
+
      <code>true</code>.</p>
-          <p>After you set the <code>cacheAsBitmap</code> property to <code>true</code>,
+
+     
+     <p>After you set the <code>cacheAsBitmap</code> property to <code>true</code>,
+
      the rendering does not change, however the display object performs pixel snapping
+
      automatically. The animation speed can be significantly faster depending
+
      on the complexity of the vector content.
+
      </p>
-          <p>The <code>cacheAsBitmap</code> property is automatically set to <code>true</code>
+
+     
+     <p>The <code>cacheAsBitmap</code> property is automatically set to <code>true</code>
+
      whenever you apply a filter to a display object (when its <code>filter</code> array is not empty),
+
      and if a display object has a filter applied to it, <code>cacheAsBitmap</code> is reported as
+
      <code>true</code> for that display object, even if you set the property to <code>false</code>.
+
      If you clear all filters for a display object, the <code>cacheAsBitmap</code> setting changes to
+
      what it was last set to.</p>
-          <p>A display object does not use a bitmap even if the <code>cacheAsBitmap</code>
+
+     
+     <p>A display object does not use a bitmap even if the <code>cacheAsBitmap</code>
+
      property is set to <code>true</code> and instead renders from vector data in the following cases:</p>
-          <ul>
-            <li>The bitmap is too large.
+
+     
+     <ul>
+
+     
+       <li>The bitmap is too large.
+
      In  AIR 1.5 and Flash Player 10, the maximum size for a bitmap image is 8,191 pixels in width or height, 
+
      and the total number of pixels cannot exceed 16,777,215 pixels. (So, if a bitmap image is 8,191 pixels 
+
      wide, it can only be 2,048 pixels high.) In Flash Player 9 and earlier, the limitation is
+
      is 2880 pixels in height and 2,880 pixels in width.</li>
-            <li>The bitmap fails to allocate (out of memory error). </li>
-          </ul>
-          <p>The <code>cacheAsBitmap</code> property is best used with movie clips that have
+
+     
+       <li>The bitmap fails to allocate (out of memory error). </li>
+
+     
+     </ul>
+
+     
+     <p>The <code>cacheAsBitmap</code> property is best used with movie clips that have
+
      mostly static content and that do not scale and rotate frequently. With such movie
+
      clips, <code>cacheAsBitmap</code> can lead to performance increases when the
+
      movie clip is translated (when its <i>x</i> and <i>y</i> position is changed).</p>
-          <span class="label">Implementation</span>
+
+     
+     <span class="label">Implementation</span>
 <br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;public function get cacheAsBitmap():<a href="../../Boolean.html">Boolean</a></code>
 <br>
@@ -1241,72 +1692,137 @@ trace(circle.cacheAsBitmap); // true</pre>
 <code>cacheAsBitmapMatrix:<a href="../geom/Matrix.html">Matrix</a></code>&nbsp;&nbsp;[read-write]<p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0          </td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     
+     </td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;2.0
+
 </td>
 </tr>
 </table>
 <p></p><p>
+
      If non-null, this Matrix object defines how a display object is rendered when 
+
      <code>cacheAsBitmap</code> is set to <code>true</code>. The application uses 
+
      this matrix as a transformation matrix that is applied when rendering the bitmap version of 
+
      the display object.
+
      
+
      <p platform="actionscript"><em>AIR profile support:</em> This feature is supported 
+
      on mobile devices, but it is not supported on desktop operating systems. It also has
+
      limited support on AIR for TV devices. 
+
      Specifically, on AIR for TV devices, supported transformations include scaling and translation,
+
      but not rotation and skewing. See 
+
      <a href="http://help.adobe.com/en_US/air/build/WS144092a96ffef7cc16ddeea2126bb46b82f-8000.html">
+
      AIR Profile Support</a> for more information regarding API support across multiple profiles.</p>
-          </p><p>With <code>cacheAsBitmapMatrix</code> set, the application retains a cached 
+
+     
+     </p><p>With <code>cacheAsBitmapMatrix</code> set, the application retains a cached 
+
      bitmap image across various 2D transformations, including translation, rotation, 
+
      and scaling. If the application uses hardware acceleration, the object will
+
      be stored in video memory as a texture. This allows the GPU to apply  
+
      the supported transformations to the object. The GPU 
+
      can perform these transformations faster than the CPU.</p>
-               <p>To use the hardware acceleration, set Rendering to GPU in 
+
+     
+     
+     <p>To use the hardware acceleration, set Rendering to GPU in 
+
      the General tab of the iPhone Settings dialog box in Flash Professional CS5.
+
      Or set the <code>renderMode</code> property to <code>gpu</code> in the 
+
      application descriptor file. Note that AIR for TV devices automatically 
+
      use hardware acceleration if it is available.</p>
-          <p>For example, the following code sends an untransformed bitmap representation
+
+     
+     <p>For example, the following code sends an untransformed bitmap representation
+
       of the display object to the GPU:</p>
+
      
+
      <div class='listing'><pre>matrix:Matrix = new Matrix(); // creates an identity matrix 
+
      mySprite.cacheAsBitmapMatrix = matrix; 
+
      mySprite.cacheAsBitmap = true;</pre></div>
+
      
+
      <p>Usually, the identity matrix (<code>new Matrix()</code>) suffices. However, 
+
      you can use another matrix, such as a scaled-down matrix, to upload 
+
      a different bitmap to the GPU. For example, the following example applies 
+
      a <code>cacheAsBitmapMatrix</code> matrix that is scaled by 0.5 on the x and y axes. 
+
      The bitmap object that the GPU uses is smaller, however the GPU adjusts 
+
      its size to match the transform.matrix property of the display object:</p>
+
      
+
      <div class='listing'><pre>matrix:Matrix = new Matrix(); // creates an identity matrix 
+
      matrix.scale(0.5, 0.5); // scales the matrix 
+
      mySprite.cacheAsBitmapMatrix = matrix; 
+
      mySprite.cacheAsBitmap = true;</pre></div>
+
      
+
      <p>Generally, you should choose to use a matrix that transforms the display object 
+
      to the size that it will appear in the application. For example, if 
+
      your application displays the bitmap version of the sprite scaled down by a half, 
+
      use a matrix that scales down by a half. If you application will display 
+
      the sprite larger than its current dimensions, use a matrix that 
+
      scales up by that factor.</p>
-          <p><strong>Note:</strong> The <code>cacheAsBitmapMatrix</code> property
+
+     
+     <p><strong>Note:</strong> The <code>cacheAsBitmapMatrix</code> property
+
      is suitable for 2D transformations. If you need to apply transformations in 3D,
+
      you may do so by setting a 3D property of the object and manipulating its 
+
      <code>transform.matrix3D</code> property. If the application is packaged 
+
      using GPU mode, this allows the 3D transforms to be applied to 
+
      the object by the GPU. The <code>cacheAsBitmapMatrix</code> is ignored 
+
      for 3D objects.</p>
-          <span class="label">Implementation</span>
+
+     
+     <span class="label">Implementation</span>
 <br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;public function get cacheAsBitmapMatrix():<a href="../geom/Matrix.html">Matrix</a></code>
 <br>
@@ -1419,7 +1935,9 @@ function timerHandler(evt:TimerEvent):void {
 <code>filters:<a href="../../Array.html">Array</a></code>&nbsp;&nbsp;[read-write]<p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0      
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+      
+
      </td>
 </tr>
 </table>
@@ -1429,84 +1947,183 @@ function timerHandler(evt:TimerEvent):void {
 </tr>
 </table>
 <p></p><p>
+
      An indexed array that contains each filter object currently associated with the display object.
+
      The flash.filters package contains several classes that define specific filters you can
+
      use.
-          </p><p>Filters can be applied in Flash Professional at design time, or at run time by using
+
+     
+     </p><p>Filters can be applied in Flash Professional at design time, or at run time by using
+
      ActionScript code. To apply a filter by using ActionScript, you must make a temporary copy of the
+
      entire <code>filters</code> array, modify the temporary array, then assign the value
+
      of the temporary array back to the <code>filters</code> array. You cannot directly
+
      add a new filter object to the <code>filters</code> array.</p>
-          <p>To add a filter by using ActionScript, perform the following steps (assume that the
+
+     
+     <p>To add a filter by using ActionScript, perform the following steps (assume that the
+
      target display object is named <code>myDisplayObject</code>):</p>
-          <ol>
-            <li>Create a new filter object by using the constructor method of your chosen filter
+
+     
+     <ol>
+
+     
+       <li>Create a new filter object by using the constructor method of your chosen filter
+
      class.</li>
-            <li>Assign the value of the <code>myDisplayObject.filters</code> array to a temporary array, such
+
+     
+       <li>Assign the value of the <code>myDisplayObject.filters</code> array to a temporary array, such
+
      as one named <code>myFilters</code>.</li>
-            <li>Add the new filter object to the <code>myFilters</code> temporary array.</li>
-            <li>Assign the value of the temporary array to the <code>myDisplayObject.filters</code> array.</li>
-          </ol>
-          <p>If the <code>filters</code> array is undefined, you do not need to use a temporary array.
+
+     
+       <li>Add the new filter object to the <code>myFilters</code> temporary array.</li>
+
+     
+       <li>Assign the value of the temporary array to the <code>myDisplayObject.filters</code> array.</li>
+
+     
+     </ol>
+
+     
+     <p>If the <code>filters</code> array is undefined, you do not need to use a temporary array.
+
      Instead, you can directly assign an array literal that contains one or more filter objects that
+
      you create. The first example in the Examples section adds a drop shadow filter by using
+
      code that handles both defined and undefined <code>filters</code> arrays.</p>
-          <p>To modify an existing filter object,
+
+     
+     <p>To modify an existing filter object,
+
      you must use the technique of modifying a copy of the <code>filters</code> array:</p>
-          <ol>
-            <li>Assign the value of the <code>filters</code> array to a temporary array, such as one
+
+     
+     <ol>
+
+     
+       <li>Assign the value of the <code>filters</code> array to a temporary array, such as one
+
      named <code>myFilters</code>.</li>
-            <li>Modify the property by using the temporary array, <code>myFilters</code>. For example, 
+
+     
+       <li>Modify the property by using the temporary array, <code>myFilters</code>. For example, 
+
      to set the quality property of the first filter in the array, you could use the
+
      following code: <code>myFilters[0].quality = 1;</code></li>
-            <li>Assign the value of the temporary array to the <code>filters</code> array.</li>
-          </ol>
-          <p>At load time, if a display object has an associated filter, it is marked to cache itself as a
+
+     
+       <li>Assign the value of the temporary array to the <code>filters</code> array.</li>
+
+     
+     </ol>
+
+     
+     <p>At load time, if a display object has an associated filter, it is marked to cache itself as a
+
      transparent bitmap. From this point forward, as long as the display object has a valid filter list,
+
      the player caches the display object as a bitmap. This source bitmap is used as a source
+
      image for the filter effects. Each display object usually has two bitmaps: one with the
+
      original unfiltered source display object and another for the final image after filtering.
+
      The final image is used when rendering. As long as the display object does not
+
      change, the final image does not need updating.</p>
-          <p>The flash.filters package includes classes for filters. For example, to create a DropShadow
+
+     
+     <p>The flash.filters package includes classes for filters. For example, to create a DropShadow
+
      filter, you would write:</p>
-          <div class='listing'><pre>
-     import flash.filters.DropShadowFilter
-     var myFilter:DropShadowFilter = new DropShadowFilter (distance, angle, color, alpha, blurX, blurY, quality, inner, knockout)
-     </pre></div>
-          <p>You can use the <code>is</code> operator to determine the type of filter assigned to 
-     each index position in the <code>filter</code> array. For example, the following code shows
-     how to determine the position of the first filter in the <code>filters</code> array that 
-     is a DropShadowFilter:
-     </p>
+
      
      <div class='listing'><pre>
+
+     import flash.filters.DropShadowFilter
+
+     var myFilter:DropShadowFilter = new DropShadowFilter (distance, angle, color, alpha, blurX, blurY, quality, inner, knockout)
+
+     </pre></div>
+
+     
+     <p>You can use the <code>is</code> operator to determine the type of filter assigned to 
+
+     each index position in the <code>filter</code> array. For example, the following code shows
+
+     how to determine the position of the first filter in the <code>filters</code> array that 
+
+     is a DropShadowFilter:
+
+     </p>
+
+     
+
+     <div class='listing'><pre>
+
      import flash.text.TextField;
+
      import flash.filters.*;
+
      var tf:TextField = new TextField();
+
      var filter1:DropShadowFilter = new DropShadowFilter();
+
      var filter2:GradientGlowFilter = new GradientGlowFilter();
+
      tf.filters = [filter1, filter2];
+
      
+
      tf.text = "DropShadow index: " + filterPosition(tf, DropShadowFilter).toString(); // 0
+
      addChild(tf)
+
      
+
      function filterPosition(displayObject:DisplayObject, filterClass:Class):int {
+
          for (var i:uint = 0; i &lt; displayObject.filters.length; i++) {
+
              if (displayObject.filters[i] is filterClass) {
+
                  return i;
+
              }
+
          }
+
          return -1;
+
      }
+
      </pre></div>
+
      <p><strong>Note:</strong> Since you cannot directly add a new filter object to the
+
      <code>DisplayObject.filters</code> array, the following code has no
+
      effect on the target display object, named <code>myDisplayObject</code>:</p>
-          <div class='listing'><pre>
+
+     
+     <div class='listing'><pre>
+
      myDisplayObject.filters.push(myDropShadow);
+
      </pre></div>
-          <span class="label">Implementation</span>
+
+     
+     <span class="label">Implementation</span>
 <br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;public function get filters():<a href="../../Array.html">Array</a></code>
 <br>
@@ -1518,10 +2135,15 @@ function timerHandler(evt:TimerEvent):void {
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20"></td><td><code><a href="../../ArgumentError.html">ArgumentError</a> </code> &mdash; When <code>filters</code> includes a ShaderFilter and the shader 
+
                            output type is not compatible with this operation 
+
                            (the shader must specify a <code>pixel4</code> 
+
                            output).
+
      
+
      </td>
 </tr>
 <tr>
@@ -1529,9 +2151,13 @@ function timerHandler(evt:TimerEvent):void {
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../ArgumentError.html">ArgumentError</a> </code> &mdash; When <code>filters</code> includes a ShaderFilter and the shader 
+
                            doesn't specify any image input or the first
+
                            input is not an <code>image4</code> input.
+
      
+
      </td>
 </tr>
 <tr>
@@ -1539,8 +2165,11 @@ function timerHandler(evt:TimerEvent):void {
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../ArgumentError.html">ArgumentError</a> </code> &mdash; When <code>filters</code> includes a ShaderFilter and the shader 
+
                            specifies an image input that isn't provided.
+
      
+
      </td>
 </tr>
 <tr>
@@ -1548,13 +2177,21 @@ function timerHandler(evt:TimerEvent):void {
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../ArgumentError.html">ArgumentError</a> </code> &mdash; When <code>filters</code> includes a ShaderFilter, a 
+
                            ByteArray or Vector.&lt;Number&gt; instance as 
+
                            a shader input, and the <code>width</code> 
+
                            and <code>height</code> properties aren't specified for the 
+
                            ShaderInput object, or the specified values don't match the amount of 
+
                            data in the input data. See the <code>ShaderInput.input</code> 
+
                            property for more information.
+
      
+
      </td>
 </tr>
 </table>
@@ -1577,7 +2214,10 @@ function timerHandler(evt:TimerEvent):void {
 <code>height:<a href="../../Number.html">Number</a></code>&nbsp;&nbsp;[read-write]<p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0           
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     
+      
+
       </td>
 </tr>
 </table>
@@ -1587,21 +2227,37 @@ function timerHandler(evt:TimerEvent):void {
 </tr>
 </table>
 <p></p><p>
+
      Indicates the height of the display object, in pixels. The height is calculated based on the bounds of the content of the display object.
+
      When you set the <code>height</code> property, the <code>scaleY</code> property is adjusted accordingly, as shown in the 
+
      following code:
+
      
+
      <div class='listing'><pre>
+
     var rect:Shape = new Shape();
+
     rect.graphics.beginFill(0xFF0000);
+
     rect.graphics.drawRect(0, 0, 100, 100);
+
     trace(rect.scaleY) // 1;
+
     rect.height = 200;
+
     trace(rect.scaleY) // 2;</pre></div>
+
     
+
     </p><p>Except for TextField and Video objects, a display object with no content (such as an empty sprite) has a height 
+
     of 0, even if you try to set <code>height</code> to a different value.</p>
-          <span class="label">Implementation</span>
+
+     
+     <span class="label">Implementation</span>
 <br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;public function get height():<a href="../../Number.html">Number</a></code>
 <br>
@@ -1645,7 +2301,9 @@ addChild(tf2);</pre>
 <code>loaderInfo:<a href="../display/LoaderInfo.html">LoaderInfo</a></code>&nbsp;&nbsp;[read-only]<p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0          </td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     
+     </td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
@@ -1654,15 +2312,25 @@ addChild(tf2);</pre>
 </tr>
 </table>
 <p></p><p>
+
      Returns a LoaderInfo object containing information about loading the file
+
      to which this display object belongs. The <code>loaderInfo</code> property is defined only
+
      for the root display object of a SWF file or for a loaded Bitmap (not for a Bitmap that is drawn 
+
      with ActionScript). To find the <code>loaderInfo</code> object associated with the SWF file that contains 
+
      a display object named <code>myDisplayObject</code>, use <code>myDisplayObject.root.loaderInfo</code>.
+
      
+
      </p><p>A large SWF file can monitor its download by calling 
+
      <code>this.root.loaderInfo.addEventListener(Event.COMPLETE, func)</code>.</p>
-          <span class="label">Implementation</span>
+
+     
+     <span class="label">Implementation</span>
 <br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;public function get loaderInfo():<a href="../display/LoaderInfo.html">LoaderInfo</a></code>
 <br>
@@ -1695,7 +2363,10 @@ addChild(tf2);</pre>
 <code>mask:<a href="../display/DisplayObject.html">DisplayObject</a></code>&nbsp;&nbsp;[read-write]<p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0           
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     
+      
+
       </td>
 </tr>
 </table>
@@ -1705,27 +2376,50 @@ addChild(tf2);</pre>
 </tr>
 </table>
 <p></p><p>
+
      The calling display object is masked by the specified <code>mask</code> object.
+
      To ensure that masking works when the Stage is scaled, the <code>mask</code> display object
+
      must be in an active part of the display list. The <code>mask</code> object itself is not drawn.
+
      Set <code>mask</code> to <code>null</code> to remove the mask.
+
      
+
      </p><p>To be able to scale a mask object, it must be on the display list. To be able to drag a mask Sprite object 
+
      (by calling its <code>startDrag()</code> method), it must be on the display list. To call the 
+
      <code>startDrag()</code> method for a mask sprite based on a <code>mouseDown</code> event 
+
      being dispatched by the sprite, set the sprite's <code>buttonMode</code> property to <code>true</code>.</p>
-          <p>When display objects are cached by setting the <code>cacheAsBitmap</code> property to
-     <code>true</code> an the <code>cacheAsBitmapMatrix</code> property to a Matrix object, 
-     both the mask and the display object being masked must be part of the same cached
-     bitmap. Thus, if the display object is cached, then the mask must be a child of the display object.
-     If an ancestor of the display object on the display list is cached, then the mask must be a child of
-     that ancestor or one of its descendents. If more than one ancestor of the masked object is cached, 
-     then the mask must be a descendent of the cached container closest to the masked object in the display list.</p>
+
      
+     <p>When display objects are cached by setting the <code>cacheAsBitmap</code> property to
+
+     <code>true</code> an the <code>cacheAsBitmapMatrix</code> property to a Matrix object, 
+
+     both the mask and the display object being masked must be part of the same cached
+
+     bitmap. Thus, if the display object is cached, then the mask must be a child of the display object.
+
+     If an ancestor of the display object on the display list is cached, then the mask must be a child of
+
+     that ancestor or one of its descendents. If more than one ancestor of the masked object is cached, 
+
+     then the mask must be a descendent of the cached container closest to the masked object in the display list.</p>
+
+     
+
      <p><b>Note:</b> A single <code>mask</code> object cannot be used to mask more than one calling display object. 
+
      When the <code>mask</code> is assigned to a second display object, it is removed as the mask of the first 
+
      object, and that object's <code>mask</code> property becomes <code>null</code>.</p>  
-          <span class="label">Implementation</span>
+
+     
+     <span class="label">Implementation</span>
 <br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;public function get mask():<a href="../display/DisplayObject.html">DisplayObject</a></code>
 <br>
@@ -1778,8 +2472,11 @@ function noDrag(event:MouseEvent):void {
 </table>
 <div class="detailBody">
 <code>metaData:<a href="../../Object.html">Object</a></code>&nbsp;&nbsp;[read-write]<p>
+
      Obtains the meta data object of the DisplayObject instance if meta data was stored alongside the
+
      the instance of this DisplayObject in the SWF file through a PlaceObject4 tag.
+
      </p><span class="label">Implementation</span>
 <br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;public function get metaData():<a href="../../Object.html">Object</a></code>
@@ -1797,7 +2494,10 @@ function noDrag(event:MouseEvent):void {
 <code>mouseX:<a href="../../Number.html">Number</a></code>&nbsp;&nbsp;[read-only]<p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0           
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     
+      
+
       </td>
 </tr>
 </table>
@@ -1807,10 +2507,16 @@ function noDrag(event:MouseEvent):void {
 </tr>
 </table>
 <p></p><p>
+
      Indicates the x coordinate of the mouse or user input device position, in pixels.
-          </p><p><strong>Note</strong>: For a DisplayObject that has been rotated, the returned x coordinate will reflect the
+
+     
+     </p><p><strong>Note</strong>: For a DisplayObject that has been rotated, the returned x coordinate will reflect the
+
      non-rotated object.</p>
-          <span class="label">Implementation</span>
+
+     
+     <span class="label">Implementation</span>
 <br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;public function get mouseX():<a href="../../Number.html">Number</a></code>
 <br>
@@ -1846,7 +2552,10 @@ function traceCoordinates(event:MouseEvent):void {
 <code>mouseY:<a href="../../Number.html">Number</a></code>&nbsp;&nbsp;[read-only]<p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0           
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     
+      
+
       </td>
 </tr>
 </table>
@@ -1856,10 +2565,16 @@ function traceCoordinates(event:MouseEvent):void {
 </tr>
 </table>
 <p></p><p>
+
      Indicates the y coordinate of the mouse or user input device position, in pixels.
-          </p><p><strong>Note</strong>: For a DisplayObject that has been rotated, the returned y coordinate will reflect the
+
+     
+     </p><p><strong>Note</strong>: For a DisplayObject that has been rotated, the returned y coordinate will reflect the
+
      non-rotated object.</p>
-          <span class="label">Implementation</span>
+
+     
+     <span class="label">Implementation</span>
 <br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;public function get mouseY():<a href="../../Number.html">Number</a></code>
 <br>
@@ -1895,7 +2610,10 @@ function traceCoordinates(event:MouseEvent):void {
 <code>name:<a href="../../String.html">String</a></code>&nbsp;&nbsp;[read-write]<p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0          
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     
+     
+
      </td>
 </tr>
 </table>
@@ -1905,10 +2623,15 @@ function traceCoordinates(event:MouseEvent):void {
 </tr>
 </table>
 <p></p><p>
+
      Indicates the instance name of the DisplayObject. The object can be identified in 
+
      the child list of its parent display object container by calling the 
+
      <code>getChildByName()</code> method of the display object container.
-          </p><span class="label">Implementation</span>
+
+     
+     </p><span class="label">Implementation</span>
 <br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;public function get name():<a href="../../String.html">String</a></code>
 <br>
@@ -1920,8 +2643,11 @@ function traceCoordinates(event:MouseEvent):void {
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20"></td><td><code><a href="../../Error.html">Error</a> </code> &mdash; If you are attempting to set this property on an object that was 
+
      placed on the timeline in the Flash authoring tool.
+
      
+
      </td>
 </tr>
 </table>
@@ -1964,7 +2690,10 @@ function traceName(event:MouseEvent):void {
 <code>opaqueBackground:<a href="../../Object.html">Object</a></code>&nbsp;&nbsp;[read-write]<p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0           
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     
+      
+
       </td>
 </tr>
 </table>
@@ -1974,24 +2703,44 @@ function traceName(event:MouseEvent):void {
 </tr>
 </table>
 <p></p><p>
+
      Specifies whether the display object is opaque with a certain background color.
+
      A transparent bitmap contains alpha
+
      channel data and is drawn transparently. An opaque bitmap has no alpha channel (and renders faster
+
      than a transparent bitmap). If the bitmap is opaque, you specify its own background color to use.
-          </p><p>If set to a number value, the surface is opaque (not transparent) with the RGB background
+
+     
+     </p><p>If set to a number value, the surface is opaque (not transparent) with the RGB background
+
      color that the number specifies. If set to <code>null</code> (the default value), the display 
+
      object has a transparent background.</p>
+
      
+
      <p>The <code>opaqueBackground</code> property is intended mainly for use with the 
+
      <code>cacheAsBitmap</code> property, for rendering optimization. For display objects in which the 
+
      <code>cacheAsBitmap</code> property is set to true, setting <code>opaqueBackground</code> can 
+
      improve rendering performance.</p>
+
      
+
      <p>The opaque background region is <em>not</em> matched when calling the <code>hitTestPoint()</code> 
+
      method with the <code>shapeFlag</code> parameter set to <code>true</code>.</p>
+
      
+
      <p>The opaque background region does not respond to mouse events.</p>
+
      
+
      <span class="label">Implementation</span>
 <br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;public function get opaqueBackground():<a href="../../Object.html">Object</a></code>
@@ -2032,7 +2781,10 @@ addChild(circle);</pre>
 <code>parent:<a href="../display/DisplayObjectContainer.html">DisplayObjectContainer</a></code>&nbsp;&nbsp;[read-only]<p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0           
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     
+      
+
       </td>
 </tr>
 </table>
@@ -2042,14 +2794,25 @@ addChild(circle);</pre>
 </tr>
 </table>
 <p></p><p>
+
      Indicates the DisplayObjectContainer object that contains this display object. Use the <code>parent</code>
+
      property to specify a relative path to display objects that are above the
+
      current display object in the display list hierarchy.
-          </p><p>You can use <code>parent</code> to move up multiple levels in the display list as in the following:</p>
-          <div class='listing'><pre>
+
+     
+     </p><p>You can use <code>parent</code> to move up multiple levels in the display list as in the following:</p>
+
+     
+     <div class='listing'><pre>
+
      this.parent.parent.alpha = 20;
+
      </pre></div>
-          <span class="label">Implementation</span>
+
+     
+     <span class="label">Implementation</span>
 <br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;public function get parent():<a href="../display/DisplayObjectContainer.html">DisplayObjectContainer</a></code>
 <br>
@@ -2059,9 +2822,13 @@ addChild(circle);</pre>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20"></td><td><code><a href="../../SecurityError.html">SecurityError</a> </code> &mdash; The parent display object belongs to a security sandbox
+
      to which you do not have access. You can avoid this situation by having
+
      the parent movie call the <code>Security.allowDomain()</code> method.
-          </td>
+
+     
+     </td>
 </tr>
 </table>
 <br>
@@ -2099,7 +2866,9 @@ trace(sprite3.parent.parent.name); // sprite1</pre>
 <code>root:<a href="../display/DisplayObject.html">DisplayObject</a></code>&nbsp;&nbsp;[read-only]<p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0      
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+      
+
       </td>
 </tr>
 </table>
@@ -2109,24 +2878,43 @@ trace(sprite3.parent.parent.name); // sprite1</pre>
 </tr>
 </table>
 <p></p><p>
+
      For a display object in a loaded SWF file, the <code>root</code> property is the 
+
      top-most display object in the portion of the display list's tree structure represented by that SWF file.
+
      For a Bitmap object representing a loaded image file, the <code>root</code> property is the Bitmap object
+
      itself. For the instance of the main class of the first SWF file loaded, the <code>root</code> property is the 
+
      display object itself. The <code>root</code> property of the Stage object is the Stage object itself. The <code>root</code>  
+
      property is set to <code>null</code> for any display object that has not been added to the display list, unless 
+
      it has been added to a display object container that is off the display list but that is a child of the 
+
      top-most display object in a loaded SWF file.
+
      
+
      </p><p>For example, if you create a new Sprite object by calling the <code>Sprite()</code> constructor method, 
+
      its <code>root</code> property is <code>null</code> until you add it to the display list (or to a display 
+
      object container that is off the display list but that is a child of the top-most display object in a SWF file).</p>
+
      
+
      <p>For a loaded SWF file, even though the Loader object used to load the file may not be on the display list, 
+
      the top-most display object in the SWF file has its <code>root</code> property set to itself.  The Loader object 
+
      does not have its <code>root</code> property set until it is added as a child of a display object for which the 
+
      <code>root</code> property is set.</p>
+
      
+
      <span class="label">Implementation</span>
 <br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;public function get root():<a href="../display/DisplayObject.html">DisplayObject</a></code>
@@ -2171,7 +2959,10 @@ function loaded(event:Event):void {
 <code>rotation:<a href="../../Number.html">Number</a></code>&nbsp;&nbsp;[read-write]<p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0           
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     
+      
+
       </td>
 </tr>
 </table>
@@ -2181,11 +2972,17 @@ function loaded(event:Event):void {
 </tr>
 </table>
 <p></p><p>
+
      Indicates the rotation of the DisplayObject instance, in degrees, from its original orientation. Values from 0 to 180 represent
+
      clockwise rotation; values from 0 to -180 represent counterclockwise rotation. Values outside this range are added to or
+
      subtracted from 360 to obtain a value within the range. For example, the statement <code>my_video.rotation = 450</code> is the
+
      same as <code> my_video.rotation = 90</code>.
-          </p><span class="label">Implementation</span>
+
+     
+     </p><span class="label">Implementation</span>
 <br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;public function get rotation():<a href="../../Number.html">Number</a></code>
 <br>
@@ -2226,21 +3023,30 @@ function rotate(event:MouseEvent):void {
 <code>rotationX:<a href="../../Number.html">Number</a></code>&nbsp;&nbsp;[read-write]<p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0           
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     
+      
+
       </td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;1.5
+
 </td>
 </tr>
 </table>
 <p></p><p>
+
      Indicates the x-axis rotation of the DisplayObject instance, in degrees, from its original orientation relative to the 3D parent container. Values from 0 to 180 represent
+
      clockwise rotation; values from 0 to -180 represent counterclockwise rotation. Values outside this range are added to or
+
      subtracted from 360 to obtain a value within the range.
-          </p><span class="label">Implementation</span>
+
+     
+     </p><span class="label">Implementation</span>
 <br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;public function get rotationX():<a href="../../Number.html">Number</a></code>
 <br>
@@ -2360,21 +3166,31 @@ function slider_change(evt:SliderEvent):void {
 <code>rotationY:<a href="../../Number.html">Number</a></code>&nbsp;&nbsp;[read-write]<p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0           
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     
+      
+
       </td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;1.5
+
 </td>
 </tr>
 </table>
 <p></p><p>
+
      Indicates the y-axis rotation of the DisplayObject instance, in degrees, from its original orientation relative to the 3D parent container. Values from 0 to 180 represent
+
      clockwise rotation; values from 0 to -180 represent counterclockwise rotation. Values outside this range are added to or
+
      subtracted from 360 to obtain a value within the range.
-               </p><span class="label">Implementation</span>
+
+     
+     
+     </p><span class="label">Implementation</span>
 <br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;public function get rotationY():<a href="../../Number.html">Number</a></code>
 <br>
@@ -2454,21 +3270,31 @@ package {
 <code>rotationZ:<a href="../../Number.html">Number</a></code>&nbsp;&nbsp;[read-write]<p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0           
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     
+      
+
       </td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;1.5
+
 </td>
 </tr>
 </table>
 <p></p><p>
+
      Indicates the z-axis rotation of the DisplayObject instance, in degrees, from its original orientation relative to the 3D parent container. Values from 0 to 180 represent
+
      clockwise rotation; values from 0 to -180 represent counterclockwise rotation. Values outside this range are added to or
+
      subtracted from 360 to obtain a value within the range.
-          
+
+     
+     
+
      </p><span class="label">Implementation</span>
 <br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;public function get rotationZ():<a href="../../Number.html">Number</a></code>
@@ -2486,7 +3312,9 @@ package {
 <code>scale9Grid:<a href="../geom/Rectangle.html">Rectangle</a></code>&nbsp;&nbsp;[read-write]<p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0          </td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     
+     </td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
@@ -2495,69 +3323,151 @@ package {
 </tr>
 </table>
 <p></p><p>
+
      The current scaling grid that is in effect. If set to <code>null</code>,
+
      the entire display object is scaled normally when any scale transformation is
+
      applied.
-          </p><p>When you define the <code>scale9Grid</code> property, the display object is divided into a
+
+     
+     </p><p>When you define the <code>scale9Grid</code> property, the display object is divided into a
+
      grid with nine regions based on the <code>scale9Grid</code> rectangle, which defines the
+
      center region of the grid. The eight other regions of the grid are the following areas: </p>
-          <ul>
+
+     
+     <ul>
+
        <li>The upper-left corner outside of the rectangle</li>
+
        <li>The area above the rectangle </li>
+
        <li>The upper-right corner outside of the rectangle</li>
+
        <li>The area to the left of the rectangle</li>
+
        <li>The area to the right of the rectangle</li>
+
        <li>The lower-left corner outside of the rectangle</li>
+
        <li>The area below the rectangle</li>
+
        <li>The lower-right corner outside of the rectangle</li>
+
      </ul>
-          <p>You can think of the eight regions outside of the center (defined by the rectangle)
+
+     
+     <p>You can think of the eight regions outside of the center (defined by the rectangle)
+
      as being like a picture frame that has special rules applied to it when scaled.</p>
-          <p>When the <code>scale9Grid</code> property is set and a display object is scaled, all text and
+
+     
+     <p>When the <code>scale9Grid</code> property is set and a display object is scaled, all text and
+
      gradients are scaled normally; however, for other types of objects the following rules apply:</p>
-          <ul>
+
+     
+     <ul>
+
        <li>Content in the center region is scaled normally. </li>
+
        <li>Content in the corners is not scaled. </li>
+
        <li>Content in the top and bottom regions is scaled horizontally only. Content in the
+
      left and right regions is scaled vertically only.</li>
+
       <li>All fills (including bitmaps, video, and gradients) are stretched to fit their shapes.</li>
+
      </ul>
-          <p>If a display object is rotated, all subsequent scaling is normal (and the
+
+     
+     <p>If a display object is rotated, all subsequent scaling is normal (and the
+
      <code>scale9Grid</code> property is ignored).</p>
-          <p>For example, consider the following display object and a rectangle that is applied as the display
+
+     
+     <p>For example, consider the following display object and a rectangle that is applied as the display
+
      object's <code>scale9Grid</code>:</p>
-          <table style="margin-left:40px" border="1" cellpadding="6" cellspacing= "0">
-            <tr>
+
+     
+     <table style="margin-left:40px" border="1" cellpadding="6" cellspacing= "0">
+
+     
+       <tr>
+
       <td align = "center"><img src="../../images/scale9Grid-a.jpg" alt="display object image" />
+
      <p>The display object.</p></td>
-           <td align = "center"><img src="../../images/scale9Grid-b.jpg" alt="display object scale 9 region" />
+
+     
+      <td align = "center"><img src="../../images/scale9Grid-b.jpg" alt="display object scale 9 region" />
+
       <p>The red rectangle shows the <code>scale9Grid</code>.</p></td>
+
        </tr>
-          </table>
-          <p>When the display object is scaled or stretched, the objects within the rectangle scale
+
+     
+     </table>
+
+     
+     <p>When the display object is scaled or stretched, the objects within the rectangle scale
+
      normally, but the objects outside of the rectangle scale according to the
+
      <code>scale9Grid</code> rules:</p>
-          <table style="margin-left:40px" border="1" cellpadding="6" cellspacing= "0">
+
+     
+     <table style="margin-left:40px" border="1" cellpadding="6" cellspacing= "0">
+
       <tr>
+
       <td>Scaled to 75%:</td>
+
       <td><img src="../../images/scale9Grid-c.jpg" alt="display object at 75%" /></td>
+
       </tr>
-           <tr>
+
+     
+      <tr>
+
       <td>Scaled to 50%:</td>
+
       <td><img src="../../images/scale9Grid-d.jpg" alt="display object at 50%" /></td>
+
       </tr>
-           <tr>
+
+     
+      <tr>
+
       <td>Scaled to 25%:</td>
+
       <td><img src="../../images/scale9Grid-e.jpg" alt="display object at 25%" /></td>
+
       </tr>
-           <tr>
+
+     
+      <tr>
+
       <td>Stretched horizontally 150%: </td>
+
       <td><img src="../../images/scale9Grid-f.jpg" alt="display stretched 150%" /></td>
+
       </tr>
-          </table>
-          <p>A common use for setting <code>scale9Grid</code> is to set up a display object to be used
+
+     
+     </table>
+
+     
+     <p>A common use for setting <code>scale9Grid</code> is to set up a display object to be used
+
      as a component, in which edge regions retain the same width when the component is scaled.</p>
-          <span class="label">Implementation</span>
+
+     
+     <span class="label">Implementation</span>
 <br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;public function get scale9Grid():<a href="../geom/Rectangle.html">Rectangle</a></code>
 <br>
@@ -2569,7 +3479,9 @@ package {
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20"></td><td><code><a href="../../ArgumentError.html">ArgumentError</a> </code> &mdash; If you pass an invalid argument to the method.
+
      
+
      </td>
 </tr>
 </table>
@@ -2648,7 +3560,10 @@ function scale(event:TimerEvent):void {
 <code>scaleX:<a href="../../Number.html">Number</a></code>&nbsp;&nbsp;[read-write]<p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0           
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     
+      
+
       </td>
 </tr>
 </table>
@@ -2658,11 +3573,18 @@ function scale(event:TimerEvent):void {
 </tr>
 </table>
 <p></p><p>
+
      Indicates the horizontal scale (percentage) of the object as applied from the registration point. The default
+
      registration point is (0,0). 1.0 equals 100% scale.
-          </p><p>Scaling the local coordinate system changes the <code>x</code> and <code>y</code> property values, which are defined in
+
+     
+     </p><p>Scaling the local coordinate system changes the <code>x</code> and <code>y</code> property values, which are defined in
+
      whole pixels. </p>
-          <span class="label">Implementation</span>
+
+     
+     <span class="label">Implementation</span>
 <br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;public function get scaleX():<a href="../../Number.html">Number</a></code>
 <br>
@@ -2702,7 +3624,9 @@ function scale(event:MouseEvent):void {
 <code>scaleY:<a href="../../Number.html">Number</a></code>&nbsp;&nbsp;[read-write]<p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0      
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+      
+
       </td>
 </tr>
 </table>
@@ -2712,11 +3636,18 @@ function scale(event:MouseEvent):void {
 </tr>
 </table>
 <p></p><p>
+
      Indicates the vertical scale (percentage) of an object as applied from the registration point of the object. The
+
      default registration point is (0,0). 1.0 is 100% scale.
-          </p><p>Scaling the local coordinate system changes the <code>x</code> and <code>y</code> property values, which are defined in
+
+     
+     </p><p>Scaling the local coordinate system changes the <code>x</code> and <code>y</code> property values, which are defined in
+
      whole pixels. </p>
-          <span class="label">Implementation</span>
+
+     
+     <span class="label">Implementation</span>
 <br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;public function get scaleY():<a href="../../Number.html">Number</a></code>
 <br>
@@ -2756,21 +3687,31 @@ function scale(event:MouseEvent):void {
 <code>scaleZ:<a href="../../Number.html">Number</a></code>&nbsp;&nbsp;[read-write]<p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0     </td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     </td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;1.5
+
 </td>
 </tr>
 </table>
 <p></p><p>
+
      Indicates the depth scale (percentage) of an object as applied from the registration point of the object. The
+
      default registration point is (0,0). 1.0 is 100% scale.
-          </p><p>Scaling the local coordinate system changes the <code>x</code>, <code>y</code> and <code>z</code> property values, which are defined in
+
+     
+     </p><p>Scaling the local coordinate system changes the <code>x</code>, <code>y</code> and <code>z</code> property values, which are defined in
+
      whole pixels. </p>
-          
+
+     
+     
+
      <span class="label">Implementation</span>
 <br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;public function get scaleZ():<a href="../../Number.html">Number</a></code>
@@ -2794,7 +3735,9 @@ function scale(event:MouseEvent):void {
 <code>scrollRect:<a href="../geom/Rectangle.html">Rectangle</a></code>&nbsp;&nbsp;[read-write]<p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0      
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+      
+
      </td>
 </tr>
 </table>
@@ -2804,28 +3747,53 @@ function scale(event:MouseEvent):void {
 </tr>
 </table>
 <p></p><p>
+
      The scroll rectangle bounds of the display object. 
+
      The display object is cropped to the size 
+
      defined by the rectangle, and it scrolls within the rectangle when you change the 
+
      <code>x</code> and <code>y</code> properties of the <code>scrollRect</code> object.
+
      
+
      </p><p>The properties of the <code>scrollRect</code> Rectangle object use the display object's coordinate space 
+
      and are scaled just like the overall display object. The corner bounds of the cropped window on the scrolling 
+
      display object are the origin of the display object (0,0) and the point defined by the
+
      width and height of the rectangle. They are not centered around the origin, but 
+
      use the origin to define the upper-left corner of the area. A scrolled display object always 
+
      scrolls in whole pixel increments. </p>
+
      
+
      <p>You can scroll an object left and right by setting the <code>x</code> property of the 
+
      <code>scrollRect</code> Rectangle object. You can scroll an object up and down by setting 
+
      the <code>y</code> property of the <code>scrollRect</code> Rectangle object. If the display object 
+
      is rotated 90&#176; and you scroll it left and right, the display object actually scrolls up and down.</p>
-          <p>Note that changes to the <code>scrollRect</code> property are only processed when the object is rendered.
-     Thus methods like <code>localToGlobal</code> may not produce the expected result if called immediately
-     after modifying <code>scrollRect</code>.</p>
-          <p><strong>Note:</strong> Starting with Flash Player 11.4/AIR 3.4, negative values for the width or the height of the rectangle
-     are changed to 0.</p>
+
      
+     <p>Note that changes to the <code>scrollRect</code> property are only processed when the object is rendered.
+
+     Thus methods like <code>localToGlobal</code> may not produce the expected result if called immediately
+
+     after modifying <code>scrollRect</code>.</p>
+
+     
+     <p><strong>Note:</strong> Starting with Flash Player 11.4/AIR 3.4, negative values for the width or the height of the rectangle
+
+     are changed to 0.</p>
+
+     
+
      <span class="label">Implementation</span>
 <br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;public function get scrollRect():<a href="../geom/Rectangle.html">Rectangle</a></code>
@@ -2877,7 +3845,10 @@ function clicked(event:MouseEvent):void {
 <code>stage:<a href="../display/Stage.html">Stage</a></code>&nbsp;&nbsp;[read-only]<p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0           
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     
+      
+
       </td>
 </tr>
 </table>
@@ -2887,14 +3858,23 @@ function clicked(event:MouseEvent):void {
 </tr>
 </table>
 <p></p><p>
+
      The Stage of the display object. A Flash runtime application has only one Stage object.
+
      For example, you can create and load multiple display objects into the display list, and the
+
      <code>stage</code> property of each display object refers to the same Stage object (even if the
+
      display object belongs to a loaded SWF file).
+
      
+
      </p><p>If a display object is not added to the display list, its <code>stage</code> property is set to 
+
      <code>null</code>.</p>
-          <span class="label">Implementation</span>
+
+     
+     <span class="label">Implementation</span>
 <br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;public function get stage():<a href="../display/Stage.html">Stage</a></code>
 <br>
@@ -2935,7 +3915,9 @@ trace(stage.stageWidth);</pre>
 <code>transform:<a href="../geom/Transform.html">Transform</a></code>&nbsp;&nbsp;[read-write]<p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0         </td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+    
+     </td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
@@ -2944,42 +3926,79 @@ trace(stage.stageWidth);</pre>
 </tr>
 </table>
 <p></p><p>
+
     An object with properties pertaining to a display object's matrix, color transform, and pixel bounds.
+
     The specific properties &#8212; matrix, colorTransform, and three read-only properties 
+
     (<code>concatenatedMatrix</code>, <code>concatenatedColorTransform</code>, 
+
     and <code>pixelBounds</code>) &#8212; are described in the entry for the Transform class.
+
     
+
     </p><p>Each of the transform object's properties is itself an object. This concept is important because the only
+
     way to set new values for the matrix or colorTransform objects is to create a new object and copy that
+
     object into the transform.matrix or transform.colorTransform property.</p>
+
     
+
     <p>For example, to increase the <code>tx</code> value of a display object's matrix, you must make a
+
     copy of the entire matrix object, then copy the new object into the matrix property of the transform
+
     object:</p>
+
     
+
     <pre><code>
+
     var myMatrix:Matrix = myDisplayObject.transform.matrix;  
+
     myMatrix.tx += 10; 
+
     myDisplayObject.transform.matrix = myMatrix;  
+
     </code></pre>
+
     
+
     <p>You cannot directly set the <code>tx</code> property. The following code has
+
     no effect on <code>myDisplayObject</code>: </p>
+
     
+
     <pre><code>
+
     myDisplayObject.transform.matrix.tx += 10;
+
     </code></pre>
+
     
+
     <p>You can also copy an entire transform object and assign it to another
+
     display object's transform property. For example, the following code 
+
     copies the entire transform object from <code>myOldDisplayObj</code> to
+
     <code>myNewDisplayObj</code>:</p>
+
     <code>myNewDisplayObj.transform = myOldDisplayObj.transform;</code>
+
     <p>The resulting display object, <code>myNewDisplayObj</code>, now has the same values for its
+
     matrix, color transform, and pixel bounds as the old display object, <code>myOldDisplayObj</code>.</p>
+
     
+
     <p>Note that AIR for TV devices use hardware acceleration, if it is available, for color transforms.</p>
-        <span class="label">Implementation</span>
+
+    
+    <span class="label">Implementation</span>
 <br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;public function get transform():<a href="../geom/Transform.html">Transform</a></code>
 <br>
@@ -3042,7 +4061,10 @@ function transformer(event:MouseEvent):void {
 <code>visible:<a href="../../Boolean.html">Boolean</a></code>&nbsp;&nbsp;[read-write]<p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0           
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     
+      
+
       </td>
 </tr>
 </table>
@@ -3052,10 +4074,15 @@ function transformer(event:MouseEvent):void {
 </tr>
 </table>
 <p></p><p>
+
      Whether or not the display object is visible. Display objects that are not visible
+
      are disabled. For example, if <code>visible=false</code> for an InteractiveObject instance,
+
      it cannot be clicked.
-          </p><span class="label">Implementation</span>
+
+     
+     </p><span class="label">Implementation</span>
 <br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;public function get visible():<a href="../../Boolean.html">Boolean</a></code>
 <br>
@@ -3097,7 +4124,10 @@ function blinker(event:TimerEvent):void {
 <code>width:<a href="../../Number.html">Number</a></code>&nbsp;&nbsp;[read-write]<p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0           
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     
+      
+
       </td>
 </tr>
 </table>
@@ -3107,21 +4137,37 @@ function blinker(event:TimerEvent):void {
 </tr>
 </table>
 <p></p><p>
+
      Indicates the width of the display object, in pixels. The width is calculated based on the bounds of the content of the display object.
+
      When you set the <code>width</code> property, the <code>scaleX</code> property is adjusted accordingly, as shown in the 
+
      following code:
+
      
+
      <div class='listing'><pre>
+
     var rect:Shape = new Shape();
+
     rect.graphics.beginFill(0xFF0000);
+
     rect.graphics.drawRect(0, 0, 100, 100);
+
     trace(rect.scaleX) // 1;
+
     rect.width = 200;
+
     trace(rect.scaleX) // 2;</pre></div>
+
     
+
     </p><p>Except for TextField and Video objects, a display object with no content (such as an empty sprite) has a width 
+
     of 0, even if you try to set <code>width</code> to a different value.</p>
-          <span class="label">Implementation</span>
+
+     
+     <span class="label">Implementation</span>
 <br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;public function get width():<a href="../../Number.html">Number</a></code>
 <br>
@@ -3161,7 +4207,10 @@ function widen(event:MouseEvent):void {
 <code>x:<a href="../../Number.html">Number</a></code>&nbsp;&nbsp;[read-write]<p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0           
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     
+      
+
       </td>
 </tr>
 </table>
@@ -3171,13 +4220,21 @@ function widen(event:MouseEvent):void {
 </tr>
 </table>
 <p></p><p>
+
      Indicates the <i>x</i> coordinate of the DisplayObject instance relative to the local coordinates of
+
      the parent DisplayObjectContainer. If the object is inside a DisplayObjectContainer that has
+
      transformations, it is in the local coordinate system of the enclosing DisplayObjectContainer.
+
      Thus, for a DisplayObjectContainer rotated 90&#176; counterclockwise, the DisplayObjectContainer's
+
      children inherit a coordinate system that is rotated 90&#176; counterclockwise.
+
      The object's coordinates refer to the registration point position.
-          </p><span class="label">Implementation</span>
+
+     
+     </p><span class="label">Implementation</span>
 <br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;public function get x():<a href="../../Number.html">Number</a></code>
 <br>
@@ -3228,7 +4285,10 @@ function bounce(event:TimerEvent):void {
 <code>y:<a href="../../Number.html">Number</a></code>&nbsp;&nbsp;[read-write]<p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0           
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     
+      
+
       </td>
 </tr>
 </table>
@@ -3238,13 +4298,21 @@ function bounce(event:TimerEvent):void {
 </tr>
 </table>
 <p></p><p>
+
      Indicates the <i>y</i> coordinate of the DisplayObject instance relative to the local coordinates of
+
      the parent DisplayObjectContainer. If the object is inside a DisplayObjectContainer that has
+
      transformations, it is in the local coordinate system of the enclosing DisplayObjectContainer.
+
      Thus, for a DisplayObjectContainer rotated 90&#176; counterclockwise, the DisplayObjectContainer's
+
      children inherit a coordinate system that is rotated 90&#176; counterclockwise.
+
      The object's coordinates refer to the registration point position.
-          </p><span class="label">Implementation</span>
+
+     
+     </p><span class="label">Implementation</span>
 <br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;public function get y():<a href="../../Number.html">Number</a></code>
 <br>
@@ -3288,31 +4356,49 @@ addChild(tf2);</pre>
 <code>z:<a href="../../Number.html">Number</a></code>&nbsp;&nbsp;[read-write]<p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0     </td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     </td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;1.5
+
 </td>
 </tr>
 </table>
 <p></p><p>
+
      Indicates the z coordinate position along the z-axis of the DisplayObject
+
      instance relative to the 3D parent container. The z property is used for
+
      3D coordinates, not screen or pixel coordinates. 
+
      </p><p>When you set a <code>z</code> property for a display object to something other than the default 
+
      value of <code>0</code>, a corresponding Matrix3D object is automatically created. for adjusting a 
+
      display object's position and orientation
+
      in three dimensions. When working with the z-axis, 
+
      the existing behavior of x and y properties changes from screen or pixel coordinates to
+
      positions relative to the 3D parent container.</p>
+
      <p>For example, a child of the <code>_root</code>  at position x = 100, y = 100, z = 200
+
      is not drawn at pixel location (100,100). The child is drawn wherever the 3D projection
+
      calculation puts it. The calculation is:</p>
+
      <p><code> (x*cameraFocalLength/cameraRelativeZPosition, y*cameraFocalLength/cameraRelativeZPosition)</code></p>
+
      
-          <span class="label">Implementation</span>
+
+     
+     <span class="label">Implementation</span>
 <br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;public function get z():<a href="../../Number.html">Number</a></code>
 <br>
@@ -3409,7 +4495,8 @@ package {
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0     </td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     </td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
@@ -3418,36 +4505,68 @@ package {
 </tr>
 </table>
 <p></p><p>
+
      Returns a rectangle that defines the area of the display object relative to the coordinate system
+
      of the <code>targetCoordinateSpace</code> object.
+
      Consider the following code, which shows how the rectangle returned can vary depending on the
+
      <code>targetCoordinateSpace</code> parameter that you pass to the method:
-          <div class='listing'><pre>
-     var container:Sprite = new Sprite();
-     container.x = 100;
-     container.y = 100;
-     this.addChild(container);
-     var contents:Shape = new Shape();
-     contents.graphics.drawCircle(0,0,100);
-     container.addChild(contents);
-     trace(contents.getBounds(container));
-      // (x=-100, y=-100, w=200, h=200)
-     trace(contents.getBounds(this));
-      // (x=0, y=0, w=200, h=200)
-     </pre></div>
-               </p><p><strong>Note:</strong> Use the <code>localToGlobal()</code> and
-     <code>globalToLocal()</code> methods to convert the display object's local coordinates
-     to display coordinates, or display coordinates to local coordinates, respectively.</p>
+
      
+     <div class='listing'><pre>
+
+     var container:Sprite = new Sprite();
+
+     container.x = 100;
+
+     container.y = 100;
+
+     this.addChild(container);
+
+     var contents:Shape = new Shape();
+
+     contents.graphics.drawCircle(0,0,100);
+
+     container.addChild(contents);
+
+     trace(contents.getBounds(container));
+
+      // (x=-100, y=-100, w=200, h=200)
+
+     trace(contents.getBounds(this));
+
+      // (x=0, y=0, w=200, h=200)
+
+     </pre></div>
+
+     
+     
+     </p><p><strong>Note:</strong> Use the <code>localToGlobal()</code> and
+
+     <code>globalToLocal()</code> methods to convert the display object's local coordinates
+
+     to display coordinates, or display coordinates to local coordinates, respectively.</p>
+
+     
+
      <p>The <code>getBounds()</code> method is similar to the <code>getRect()</code> method; 
+
      however, the Rectangle returned by the <code>getBounds()</code> method includes any strokes 
+
      on shapes, whereas the Rectangle returned by the <code>getRect()</code> method does not. 
+
      For an example, see the description of the <code>getRect()</code> method.</p>
-          <span class="label">Parameters</span>
+
+     
+     <span class="label">Parameters</span>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20px"></td><td><code><span class="label">targetCoordinateSpace</span>:<a href="DisplayObject.html">DisplayObject</a></code> &mdash; The display object that defines the coordinate system to use.
-          </td>
+
+     
+     </td>
 </tr>
 </table>
 <p></p>
@@ -3456,8 +4575,11 @@ package {
 <tr>
 <td width="20"></td><td><code><a href="../geom/Rectangle.html">Rectangle</a></code> &mdash; 
                         The rectangle that defines the area of the display object relative to
+
      the <code>targetCoordinateSpace</code> object's coordinate system.
-          
+
+     
+     
                         
                      </td>
 </tr>
@@ -3484,7 +4606,8 @@ package {
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0    </td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+    </td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
@@ -3493,20 +4616,32 @@ package {
 </tr>
 </table>
 <p></p><p>
+
     Returns a rectangle that defines the boundary of the display object, 
+
     based on the coordinate system defined by the <code>targetCoordinateSpace</code> 
+
     parameter, excluding any strokes on shapes. The values that the <code>getRect()</code> method
+
     returns are the same or smaller than those returned by the <code>getBounds()</code> method.
+
     
+
     </p><p><b>Note:</b> Use <code>localToGlobal()</code> and <code>globalToLocal()</code> methods 
+
     to convert the display object's local coordinates to Stage coordinates, or Stage coordinates to 
+
     local coordinates, respectively.</p>
+
     
+
     <span class="label">Parameters</span>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20px"></td><td><code><span class="label">targetCoordinateSpace</span>:<a href="DisplayObject.html">DisplayObject</a></code> &mdash; The display object that defines the coordinate system to use.
+
     
+
     </td>
 </tr>
 </table>
@@ -3516,8 +4651,11 @@ package {
 <tr>
 <td width="20"></td><td><code><a href="../geom/Rectangle.html">Rectangle</a></code> &mdash; 
                         The rectangle that defines the area of the display object relative to
+
     the <code>targetCoordinateSpace</code> object's coordinate system.
+
     
+
     
                         
                      </td>
@@ -3580,7 +4718,9 @@ trace(triangle.getRect(this));     // (x=0, y=0, w=100, h=100)</pre>
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0          </td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     
+     </td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
@@ -3589,20 +4729,34 @@ trace(triangle.getRect(this));     // (x=0, y=0, w=100, h=100)</pre>
 </tr>
 </table>
 <p></p><p>
+
      Converts the <code>point</code> object from the Stage (global) coordinates
+
      to the display object's (local) coordinates.
-          </p><p>To use this method, first create an instance of the Point class. The
+
+     
+     </p><p>To use this method, first create an instance of the Point class. The
+
      <em>x</em> and <em>y</em> values that you assign represent global coordinates because they
+
      relate to the origin (0,0) of the main display area. Then pass the Point instance
+
      as the parameter to the <code>globalToLocal()</code> method. The method returns a new Point object with
+
      <em>x</em> and <em>y</em> values that relate to the origin of the display object
+
      instead of the origin of the Stage.</p>
-          <span class="label">Parameters</span>
+
+     
+     <span class="label">Parameters</span>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20px"></td><td><code><span class="label">point</span>:<a href="../geom/Point.html">Point</a></code> &mdash; An object created with the Point class. The Point object
+
      specifies the <i>x</i> and <i>y</i> coordinates as properties.
-          </td>
+
+     
+     </td>
 </tr>
 </table>
 <p></p>
@@ -3611,7 +4765,9 @@ trace(triangle.getRect(this));     // (x=0, y=0, w=100, h=100)</pre>
 <tr>
 <td width="20"></td><td><code><a href="../geom/Point.html">Point</a></code> &mdash; 
                         A Point object with coordinates relative to the display object.
-          
+
+     
+     
                         
                      </td>
 </tr>
@@ -3670,32 +4826,50 @@ trace(circle.globalToLocal(point3)); // [x=20, y=20]</pre>
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0      
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+      
+
       </td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;1.5
+
 </td>
 </tr>
 </table>
 <p></p><p>
+
      Converts a two-dimensional point from the Stage (global) coordinates to a
+
      three-dimensional display object's (local) coordinates.
-          </p><p>To use this method, first create an instance of the Point class. 
+
+     
+     </p><p>To use this method, first create an instance of the Point class. 
+
      The x and y values that you assign to the Point object represent global 
+
      coordinates because they are relative to the origin (0,0) of the main display area. 
+
      Then pass the Point object to the <code>globalToLocal3D()</code> 
+
      method as the <code>point</code> parameter. The method returns three-dimensional 
+
      coordinates as a Vector3D object containing <code>x</code>, <code>y</code>, and 
+
      <code>z</code> values that are relative to the origin 
+
      of the three-dimensional display object.</p>
-          <span class="label">Parameters</span>
+
+     
+     <span class="label">Parameters</span>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20px"></td><td><code><span class="label">point</span>:<a href="../geom/Point.html">Point</a></code> &mdash; A two dimensional Point object representing global x and y coordinates.
-          </td>
+
+     
+     </td>
 </tr>
 </table>
 <p></p>
@@ -3704,8 +4878,11 @@ trace(circle.globalToLocal(point3)); // [x=20, y=20]</pre>
 <tr>
 <td width="20"></td><td><code><a href="../geom/Vector3D.html">Vector3D</a></code> &mdash; 
                         A Vector3D object with coordinates relative to the three-dimensional
+
      display object. 
-          
+
+     
+     
                         
                      </td>
 </tr>
@@ -3722,7 +4899,9 @@ trace(circle.globalToLocal(point3)); // [x=20, y=20]</pre>
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0          </td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     
+     </td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
@@ -3731,13 +4910,19 @@ trace(circle.globalToLocal(point3)); // [x=20, y=20]</pre>
 </tr>
 </table>
 <p></p><p>
+
      Evaluates the bounding box of the display object to see if it overlaps or intersects with the
+
      bounding box of the <code>obj</code> display object.
-          </p><span class="label">Parameters</span>
+
+     
+     </p><span class="label">Parameters</span>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20px"></td><td><code><span class="label">obj</span>:<a href="DisplayObject.html">DisplayObject</a></code> &mdash; The display object to test against.
-          </td>
+
+     
+     </td>
 </tr>
 </table>
 <p></p>
@@ -3746,7 +4931,10 @@ trace(circle.globalToLocal(point3)); // [x=20, y=20]</pre>
 <tr>
 <td width="20"></td><td><code><a href="../../Boolean.html">Boolean</a></code> &mdash; 
                         <code>true</code> if the bounding boxes of the display objects intersect; <code>false</code> if not.
-           
+
+     
+      
+
       
                         
                      </td>
@@ -3798,7 +4986,9 @@ trace(circle2.hitTestObject(circle3)); // true</pre>
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0          </td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     
+     </td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
@@ -3807,31 +4997,45 @@ trace(circle2.hitTestObject(circle3)); // true</pre>
 </tr>
 </table>
 <p></p><p>
+
      Evaluates the display object to see if it overlaps or intersects with the
+
      point specified by the <code>x</code> and <code>y</code> parameters.
+
      The <code>x</code> and <code>y</code> parameters specify a point in the 
+
      coordinate space of the Stage, not the display object container that contains the 
+
      display object (unless that display object container is the Stage).
-          </p><span class="label">Parameters</span>
+
+     
+     </p><span class="label">Parameters</span>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20px"></td><td><code><span class="label">x</span>:<a href="../../Number.html">Number</a></code> &mdash; The <em>x</em> coordinate to test against this object.
-          </td>
+
+     
+     </td>
 </tr>
 <tr>
 <td class="paramSpacer">&nbsp;</td>
 </tr>
 <tr>
 <td width="20px"></td><td><code><span class="label">y</span>:<a href="../../Number.html">Number</a></code> &mdash; The <em>y</em> coordinate to test against this object.
-          </td>
+
+     
+     </td>
 </tr>
 <tr>
 <td class="paramSpacer">&nbsp;</td>
 </tr>
 <tr>
 <td width="20px"></td><td><code><span class="label">shapeFlag</span>:<a href="../../Boolean.html">Boolean</a></code> (default = <code>false</code>)<code></code> &mdash; Whether to check against the actual pixels of the object (<code>true</code>)
+
      or the bounding box (<code>false</code>). 
-          </td>
+
+     
+     </td>
 </tr>
 </table>
 <p></p>
@@ -3840,8 +5044,11 @@ trace(circle2.hitTestObject(circle3)); // true</pre>
 <tr>
 <td width="20"></td><td><code><a href="../../Boolean.html">Boolean</a></code> &mdash; 
                         <code>true</code> if the display object overlaps or intersects with the specified point;
+
      <code>false</code> otherwise.
-          
+
+     
+     
                         
                      </td>
 </tr>
@@ -3898,34 +5105,55 @@ trace(circle.globalToLocal(point3)); // [x=20, y=20]</pre>
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0      
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+      
+
       </td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;1.5
+
 </td>
 </tr>
 </table>
 <p></p><p>
+
      Converts a three-dimensional point of the three-dimensional display 
+
      object's (local) coordinates to a two-dimensional point in the Stage (global) coordinates.
-          </p><p>For example, you can only use two-dimensional coordinates (x,y) to
+
+     
+     </p><p>For example, you can only use two-dimensional coordinates (x,y) to
+
      draw with the <code>display.Graphics</code> methods. To draw a three-dimensional
+
      object, you need to map the three-dimensional coordinates of a
+
      display object to two-dimensional coordinates. First, create an instance of 
+
      the Vector3D class that holds the x-, y-, and z- coordinates of the three-dimensional
+
      display object. Then pass the Vector3D object to the <code>local3DToGlobal()</code> 
+
      method as the <code>point3d</code> parameter. The method returns a two-dimensional Point 
+
      object that can be used 
+
      with the Graphics API to draw the three-dimensional object.</p>
-               <span class="label">Parameters</span>
+
+     
+     
+     <span class="label">Parameters</span>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20px"></td><td><code><span class="label">point3d</span>:<a href="../geom/Vector3D.html">Vector3D</a></code> &mdash; A Vector3D object containing either a three-dimensional point or 
+
      the coordinates of the three-dimensional display object.
-          </td>
+
+     
+     </td>
 </tr>
 </table>
 <p></p>
@@ -3934,8 +5162,11 @@ trace(circle.globalToLocal(point3)); // [x=20, y=20]</pre>
 <tr>
 <td width="20"></td><td><code><a href="../geom/Point.html">Point</a></code> &mdash; 
                         A two-dimensional point representing a three-dimensional point
+
      in two-dimensional space.
-          
+
+     
+     
                         
                      </td>
 </tr>
@@ -4043,7 +5274,9 @@ package {
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0          </td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     
+     </td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
@@ -4052,24 +5285,44 @@ package {
 </tr>
 </table>
 <p></p><p>
+
      Converts the <code>point</code> object from the display object's (local) coordinates to the
+
      Stage (global) coordinates.
-          </p><p>This method allows you to convert any given <em>x</em> and <em>y</em> coordinates from
+
+     
+     </p><p>This method allows you to convert any given <em>x</em> and <em>y</em> coordinates from
+
      values that are relative to the origin (0,0) of a specific display object (local coordinates)
+
      to values that are relative to the origin of the Stage (global coordinates).</p>
-          <p>To use this method, first create an instance of the Point class. The
+
+     
+     <p>To use this method, first create an instance of the Point class. The
+
      <em>x</em> and <em>y</em> values that you assign represent local coordinates because they
+
      relate to the origin of the display object.</p>
-          <p>You then pass the Point instance that you created as the parameter to
+
+     
+     <p>You then pass the Point instance that you created as the parameter to
+
      the <code>localToGlobal()</code> method. The method returns a new Point object with
+
      <em>x</em> and <em>y</em> values that relate to the origin of the Stage
+
      instead of the origin of the display object.</p>
-          <span class="label">Parameters</span>
+
+     
+     <span class="label">Parameters</span>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20px"></td><td><code><span class="label">point</span>:<a href="../geom/Point.html">Point</a></code> &mdash; The name or identifier of a point created with the Point class, specifying the
+
      <em>x</em> and <em>y</em> coordinates as properties.
-          </td>
+
+     
+     </td>
 </tr>
 </table>
 <p></p>
@@ -4078,7 +5331,9 @@ package {
 <tr>
 <td width="20"></td><td><code><a href="../geom/Point.html">Point</a></code> &mdash; 
                         A Point object with coordinates relative to the Stage.
-          
+
+     
+     
                         
                      </td>
 </tr>
@@ -4137,7 +5392,9 @@ function traceCoordinates(event:MouseEvent):void {
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0  
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+  
+
   </td>
 </tr>
 </table>
@@ -4147,9 +5404,13 @@ function traceCoordinates(event:MouseEvent):void {
 </tr>
 </table>
 <p></p><p>
+
  Dispatched when a display object is added to the display list. The 
+
  following methods trigger this event: <code>DisplayObjectContainer.addChild()</code>, 
+
  <code>DisplayObjectContainer.addChildAt()</code>.
+
  </p><p>
 	The <code>Event.ADDED</code> constant defines the value of the <code>type</code> property of 
 	an <code>added</code> event object. 
@@ -4193,7 +5454,9 @@ function traceCoordinates(event:MouseEvent):void {
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0  
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+  
+
   </td>
 </tr>
 </table>
@@ -4203,10 +5466,15 @@ function traceCoordinates(event:MouseEvent):void {
 </tr>
 </table>
 <p></p><p>
+
  Dispatched when a display object is added to the on stage display list, 
+
  either directly or through the addition of a sub tree in which the display object is contained. The 
+
  following methods trigger this event: <code>DisplayObjectContainer.addChild()</code>, 
+
  <code>DisplayObjectContainer.addChildAt()</code>.
+
  </p><p>
 	The <code>Event.ADDED_TO_STAGE</code> constant defines the value of the <code>type</code> 
 	property of an <code>addedToStage</code> event object. 
@@ -4249,7 +5517,9 @@ function traceCoordinates(event:MouseEvent):void {
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0   
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0 
+  
+
   </td>
 </tr>
 </table>
@@ -4259,11 +5529,17 @@ function traceCoordinates(event:MouseEvent):void {
 </tr>
 </table>
 <p></p><p>
+
  [broadcast event] Dispatched when the playhead is entering a new 
+
  frame. If the playhead is not moving, or if there is only one frame, this event
+
  is dispatched continuously in conjunction with the frame rate. 
+
  This event is a broadcast event, which means that it is dispatched 
+
  by all display objects with a listener registered for this event.
+
  </p><p>
 	The <code>Event.ENTER_FRAME</code> constant defines the value of the <code>type</code> property of an <code>enterFrame</code> event object. 
 	</p><p><strong>Note:</strong> This event has neither a "capture phase" nor a "bubble phase",
@@ -4294,22 +5570,31 @@ function traceCoordinates(event:MouseEvent):void {
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0   
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0 
+  
+
   </td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;2
+
 </td>
 </tr>
 </table>
 <p></p><p>
+
  [broadcast event] Dispatched when the playhead is exiting the current frame. 
+
  All frame scripts have been run. If the playhead is not moving, or if there is only one frame, this event
+
  is dispatched continuously in conjunction with the frame rate. 
+
  This event is a broadcast event, which means that it is dispatched 
+
  by all display objects with a listener registered for this event.
+
  </p><p>
 	The <code>Event.EXIT_FRAME</code> constant defines the value of the <code>type</code> property of an <code>exitFrame</code> event object. 
 	</p><p><strong>Note:</strong> This event has neither a "capture phase" nor a "bubble phase",
@@ -4340,22 +5625,31 @@ function traceCoordinates(event:MouseEvent):void {
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0   
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0 
+  
+
   </td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;2
+
 </td>
 </tr>
 </table>
 <p></p><p>
+
  [broadcast event] Dispatched after the constructors of frame display objects have run but before frame scripts have run. 
+
  If the playhead is not moving, or if there is only one frame, this event
+
  is dispatched continuously in conjunction with the frame rate. 
+
  This event is a broadcast event, which means that it is dispatched 
+
  by all display objects with a listener registered for this event.
+
  </p><p>
 	The <code>Event.FRAME_CONSTRUCTED</code> constant defines the value of the <code>type</code> property of an <code>frameConstructed</code> event object. 
 	
@@ -4387,7 +5681,9 @@ function traceCoordinates(event:MouseEvent):void {
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0   
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0 
+  
+
   </td>
 </tr>
 </table>
@@ -4397,13 +5693,21 @@ function traceCoordinates(event:MouseEvent):void {
 </tr>
 </table>
 <p></p><p>
+
  Dispatched when a display object is about to be removed from the display list. 
- Two methods of the DisplayObjectContainer class generate this event: 
- <code>removeChild()</code> and <code>removeChildAt()</code>. 
+
+ Three methods of the DisplayObjectContainer class generate this event:
+
+ <code>removeChild()</code>, <code>removeChildren()</code>, and <code>removeChildAt()</code>.
+
  
+
  </p><p>The following methods of a DisplayObjectContainer object also generate this event if an object must be removed 
+
  to make room for the new object:  <code>addChild()</code>, <code>addChildAt()</code>, and 
+
  <code>setChildIndex()</code>. </p>
+
  <p>
 	The <code>Event.REMOVED</code> constant defines the value of the <code>type</code> property of
 	a <code>removed</code> event object. 
@@ -4439,7 +5743,9 @@ function traceCoordinates(event:MouseEvent):void {
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0   
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0 
+  
+
   </td>
 </tr>
 </table>
@@ -4449,14 +5755,23 @@ function traceCoordinates(event:MouseEvent):void {
 </tr>
 </table>
 <p></p><p>
+
  Dispatched when a display object is about to be removed from the display list, 
+
  either directly or through the removal of a sub tree in which the display object is contained. 
- Two methods of the DisplayObjectContainer class generate this event: 
- <code>removeChild()</code> and <code>removeChildAt()</code>. 
+
+ Three methods of the DisplayObjectContainer class generate this event:
+
+ <code>removeChild()</code>, <code>removeChildren()</code>, and <code>removeChildAt()</code>.
+
  
+
  </p><p>The following methods of a DisplayObjectContainer object also generate this event if an object must be removed 
+
  to make room for the new object:  <code>addChild()</code>, <code>addChildAt()</code>, and 
+
  <code>setChildIndex()</code>. </p>
+
  <p>
 	The <code>Event.REMOVED_FROM_STAGE</code> constant defines the value of the <code>type</code> 
 	property of a <code>removedFromStage</code> event object. 
@@ -4491,7 +5806,9 @@ function traceCoordinates(event:MouseEvent):void {
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0   
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0 
+  
+
   </td>
 </tr>
 </table>
@@ -4501,17 +5818,30 @@ function traceCoordinates(event:MouseEvent):void {
 </tr>
 </table>
 <p></p><p>
+
  [broadcast event] Dispatched when the display list is about to be updated and rendered. This event provides the last opportunity 
+
  for objects listening for this event to make changes before the display list is rendered. 
+
  You must call the <code>invalidate()</code> method 
+
  of the Stage object 
+
  each time you want a <code>render</code> event to be dispatched. <code>Render</code> events 
+
  are dispatched to an object only if there is mutual trust between it and the object that called 
+
  <code>Stage.invalidate()</code>.
+
  This event is a broadcast event, which means that it is dispatched 
+
  by all display objects with a listener registered for this event.
-  </p><p><strong>Note: </strong>This event is not dispatched if the display is 
+
+ 
+ </p><p><strong>Note: </strong>This event is not dispatched if the display is 
+
  not rendering. This is the case when the content is either minimized or obscured. </p>
+
  <p>
 	The <code>Event.RENDER</code> constant defines the value of the <code>type</code> property of a <code>render</code> event object. 
 	</p><p><strong>Note:</strong> This event has neither a "capture phase" nor a "bubble phase",
@@ -4631,11 +5961,10 @@ class CustomDisplayObject extends Sprite {
 <p></p>
 <div class="feedbackLink">
 <center>
-<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Wed Sep 28 2022, 6:12 PM GMT+01:00) : flash.display.DisplayObject">Submit Feedback</a>
+<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Mon Jun 30 2025, 11:00 AM GMT+01:00) : flash.display.DisplayObject">Submit Feedback</a>
 </center>
 </div>
-<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Wed Sep 28 2022, 6:12 PM GMT+01:00<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
+<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Mon Jun 30 2025, 11:00 AM GMT+01:00<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
 </div>
 </body>
-</html>
-<!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Wed Sep 28 2022, 6:12 PM GMT+01:00 <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->
+</html><!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Mon Jun 30 2025, 11:00 AM GMT+01:00 <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->

--- a/static/reference/actionscript/3.0/flash/display3D/textures/CubeTexture.html
+++ b/static/reference/actionscript/3.0/flash/display3D/textures/CubeTexture.html
@@ -43,12 +43,21 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 </tr>
 </table>
 <p></p>
+
  The CubeTexture class represents a cube texture uploaded to a rendering context.
-  <p>Defines a cube map texture for use during rendering.  Cube mapping is used for many 
+
+ 
+ <p>Defines a cube map texture for use during rendering.  Cube mapping is used for many 
+
  rendering techniques, such as environment maps, skyboxes, and skylight illumination.</p>
-  <p>You cannot create a CubeTexture object directly; use the  
+
+ 
+ <p>You cannot create a CubeTexture object directly; use the  
+
  Context3D <code>createCubeTexture()</code> instead.</p>
-  <p></p>
+
+ 
+ <p></p>
 <p>
 <span class="classHeaderTableLabel">See also</span>
 </p>
@@ -223,6 +232,7 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="#uploadCompressedTextureFromByteArray()">uploadCompressedTextureFromByteArray</a>(data:<a href="../../utils/ByteArray.html">ByteArray</a>, byteArrayOffset:<a href="../../../uint.html">uint</a>, async:<a href="../../../Boolean.html">Boolean</a> = false):<a href="../../../specialTypes.html#void">void</a>
 </div>
 <div class="summaryTableDescription">
+
      Uploads a cube texture in Adobe Texture Format (ATF) from a byte array.</div>
 </td><td class="summaryTableOwnerCol">CubeTexture</td>
 </tr>
@@ -232,6 +242,7 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="#uploadFromBitmapData()">uploadFromBitmapData</a>(source:<a href="../../display/BitmapData.html">BitmapData</a>, side:<a href="../../../uint.html">uint</a>, miplevel:<a href="../../../uint.html">uint</a> = 0):<a href="../../../specialTypes.html#void">void</a>
 </div>
 <div class="summaryTableDescription">
+
      Uploads a component of a cube map texture from a BitmapData object.</div>
 </td><td class="summaryTableOwnerCol">CubeTexture</td>
 </tr>
@@ -241,6 +252,7 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="#uploadFromByteArray()">uploadFromByteArray</a>(data:<a href="../../utils/ByteArray.html">ByteArray</a>, byteArrayOffset:<a href="../../../uint.html">uint</a>, side:<a href="../../../uint.html">uint</a>, miplevel:<a href="../../../uint.html">uint</a> = 0):<a href="../../../specialTypes.html#void">void</a>
 </div>
 <div class="summaryTableDescription">
+
      Uploads a component of a cube map texture from a ByteArray object.</div>
 </td><td class="summaryTableOwnerCol">CubeTexture</td>
 </tr>
@@ -277,7 +289,7 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a onclick="javascript:setInheritedVisible(true,'Event');" href="#eventSummary" class="showHideLink"><img alt="Show Inherited Events" src="../../../images/collapsed.gif" class="showHideLinkImage"> Show Inherited Events</a>
 </div>
 </div>
-<table id="summaryTableEvent" class="summaryTable hideInheritedEvent" cellpadding="3" cellspacing="0">
+<table id="summaryTableEvent" class="summaryTable " cellpadding="3" cellspacing="0">
 <tr>
 <th>&nbsp;</th><th colspan="2">Event</th><th>Summary</th><th class="summaryTableOwnerCol">Defined&nbsp;by</th>
 </tr>
@@ -299,6 +311,28 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
  [broadcast event] Dispatched when the <span platform="actionscript">Flash Player or</span> AIR application operating
  loses system focus and is becoming inactive.</td><td class="summaryTableOwnerCol"><a href="../../events/EventDispatcher.html">EventDispatcher</a></td>
 </tr>
+<tr class="">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol">
+<div class="summarySignature">
+<a class="signatureLink" href="#event:error">error</a>
+</div>
+</td><td class="summaryTableDescription summaryTableCol">
+
+ Dispatched by the CubeTexture object when an asynchronous texture upload
+
+ operation fails in some way.</td><td class="summaryTableOwnerCol">CubeTexture</td>
+</tr>
+<tr class="">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol">
+<div class="summarySignature">
+<a class="signatureLink" href="#event:textureReady">textureReady</a>
+</div>
+</td><td class="summaryTableDescription summaryTableCol">
+
+ Dispatched by the CubeTexture object when an asynchronous texture upload
+
+ operation has completed successfully, and the texture can then be used.</td><td class="summaryTableOwnerCol">CubeTexture</td>
+</tr>
 </table>
 </div>
 <script type="text/javascript" language="javascript">
@@ -319,24 +353,33 @@ showHideInherited();
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0     </td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     </td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3
+
 </td>
 </tr>
 </table>
 <p></p><p>
+
      Uploads a cube texture in Adobe Texture Format (ATF) from a byte array.
-          </p><p>The byte array must contain all faces and mipmaps for the texture.</p>
+
      
+     </p><p>The byte array must contain all faces and mipmaps for the texture.</p>
+
+     
+
      <span class="label">Parameters</span>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20px"></td><td><code><span class="label">data</span>:<a href="../../utils/ByteArray.html">ByteArray</a></code> &mdash; a byte array that containing a compressed cube texture 
+
      including mipmaps. The ByteArray object must use the little endian format.
+
      </td>
 </tr>
 <tr>
@@ -344,7 +387,9 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20px"></td><td><code><span class="label">byteArrayOffset</span>:<a href="../../../uint.html">uint</a></code> &mdash; an optional offset at which to start reading the 
+
      texture data.
+
 	 </td>
 </tr>
 <tr>
@@ -352,10 +397,15 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20px"></td><td><code><span class="label">async</span>:<a href="../../../Boolean.html">Boolean</a></code> (default = <code>false</code>)<code></code> &mdash;  If true, this function returns immediately.  Any draw method
+
 	 which attempts to use the texture will fail until the upload completes successfully.  Upon successful
-	 upload, this <code>Texture</code> object dispatches <code>Event.TEXTURE_READY</code>.  
+
+	 upload, this <code>CubeTexture</code> object dispatches <code>Event.TEXTURE_READY</code>.
+
 	 Default value: false.  
-     	 </td>
+
+     
+	 </td>
 </tr>
 </table>
 <br>
@@ -363,6 +413,7 @@ showHideInherited();
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20"></td><td><code><a href="../../../TypeError.html">TypeError</a> </code> &mdash; Null Pointer Error: when <code>data</code> is null.
+
      </td>
 </tr>
 <tr>
@@ -370,7 +421,9 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../ArgumentError.html">ArgumentError</a> </code> &mdash; Texture Decoding Failed: when the compression format of this object cannot be 
+
      derived from the format of the compressed data in <code>data</code>.
+
      </td>
 </tr>
 <tr>
@@ -378,7 +431,9 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../ArgumentError.html">ArgumentError</a> </code> &mdash; Texture Needs To Be Square: when the decompressed texture does not have 
+
      equal width and height.
+
      </td>
 </tr>
 <tr>
@@ -386,7 +441,9 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../ArgumentError.html">ArgumentError</a> </code> &mdash; Texture Size Does Not Match: when the width and height of the decompressed 
+
      texture do not equal the length of the texture's edge.
+
      </td>
 </tr>
 <tr>
@@ -394,7 +451,9 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../ArgumentError.html">ArgumentError</a> </code> &mdash; Miplevel Too Large: if the mip level of the decompressed texture is greater 
+
      than that implied by the length of the texture's edge.
+
      </td>
 </tr>
 <tr>
@@ -402,7 +461,9 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../ArgumentError.html">ArgumentError</a> </code> &mdash; Texture Format Mismatch: if the decoded ATF bytes don't contain a texture  
+
      compatible with this texture's format or is not a cube texture.
+
      </td>
 </tr>
 <tr>
@@ -410,6 +471,7 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../Error.html">Error</a> </code> &mdash; 3768: The <code>Stage3D</code> API may not be used during background execution.
+
 	 </td>
 </tr>
 <tr>
@@ -417,10 +479,15 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../RangeError.html">RangeError</a> </code> &mdash; Bad Input Size: when there is integer overflow of <code>byteArrayOffset</code> or 
+
 	  if <code>byteArrayOffset</code> + 6 is greater than the length of <code>data</code>, or if the 
+
 	  number of bytes available from <code>byteArrayOffset</code> to the end of the <code>data</code> byte array
+
 	  is less than the amount of data required for ATF texture.
-          </td>
+
+     
+     </td>
 </tr>
 </table>
 <p>
@@ -441,25 +508,35 @@ showHideInherited();
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0     </td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     </td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3
+
 </td>
 </tr>
 </table>
 <p></p><p>
+
      Uploads a component of a cube map texture from a BitmapData object.
-          </p><p>This function uploads one mip level of one side of the cube map. 
-     Call <code>uploadFromBitmapData()</code> as necessary to upload each mip level and face of the
-     cube map.</p>
+
      
+     </p><p>This function uploads one mip level of one side of the cube map. 
+
+     Call <code>uploadFromBitmapData()</code> as necessary to upload each mip level and face of the
+
+     cube map.</p>
+
+     
+
      <span class="label">Parameters</span>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20px"></td><td><code><span class="label">source</span>:<a href="../../display/BitmapData.html">BitmapData</a></code> &mdash; a bitmap.
+
      </td>
 </tr>
 <tr>
@@ -467,12 +544,19 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20px"></td><td><code><span class="label">side</span>:<a href="../../../uint.html">uint</a></code> &mdash; A code indicating which side of the cube to upload:  
+
      <p><ul>positive X : 0</ul>
+
         <ul>negative X : 1</ul>
+
         <ul>positive Y : 2</ul>
+
         <ul>negative Y : 3</ul>
+
         <ul>positive Z : 4</ul>
+
         <ul>negative Z : 5</ul></p>
+
      </td>
 </tr>
 <tr>
@@ -480,8 +564,11 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20px"></td><td><code><span class="label">miplevel</span>:<a href="../../../uint.html">uint</a></code> (default = <code>0</code>)<code></code> &mdash; the mip level to be loaded, level zero being the top-level
+
       full-resolution image.  The default value is zero.  
-          </td>
+
+     
+     </td>
 </tr>
 </table>
 <br>
@@ -489,6 +576,7 @@ showHideInherited();
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20"></td><td><code><a href="../../../TypeError.html">TypeError</a> </code> &mdash; Null Pointer Error: if <code>source</code> is <code>null</code>.
+
      </td>
 </tr>
 <tr>
@@ -496,7 +584,9 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../ArgumentError.html">ArgumentError</a> </code> &mdash; Miplevel Too Large: if the specified mip level is greater than 
+
      that implied by the the texture's dimensions.
+
      </td>
 </tr>
 <tr>
@@ -504,6 +594,7 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../ArgumentError.html">ArgumentError</a> </code> &mdash; Invalid Cube Side: if <code>side</code> is greater than 5.
+
      </td>
 </tr>
 <tr>
@@ -511,8 +602,11 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../ArgumentError.html">ArgumentError</a> </code> &mdash; Invalid BitmapData Error: if <code>source</code> if the BitmapData 
+
      object does not contain a valid cube texture face. The image must be square, with sides
+
      equal to a power of two, and the correct size for the miplevel specified.    
+
      </td>
 </tr>
 <tr>
@@ -520,7 +614,9 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../ArgumentError.html">ArgumentError</a> </code> &mdash; Texture Format Mismatch: if the texture format is Context3DTextureFormat.COMPRESSED or 
+
      Context3DTextureFormat.COMPRESSED_ALPHA and the code is executing on a mobile platform where runtime texture compression is not supported.
+
      </td>
 </tr>
 <tr>
@@ -528,7 +624,9 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../Error.html">Error</a> </code> &mdash; 3768: The <code>Stage3D</code> API may not be used during background execution.
-          </td>
+
+     
+     </td>
 </tr>
 </table>
 </div>
@@ -543,25 +641,36 @@ showHideInherited();
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0     </td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     </td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3
+
 </td>
 </tr>
 </table>
 <p></p><p>
+
      Uploads a component of a cube map texture from a ByteArray object.
-          </p><p>This function uploads one mip level of one side of the cube map. 
+
+     
+     </p><p>This function uploads one mip level of one side of the cube map. 
+
      Call <code>uploadFromByteArray()</code> as neccessary to upload each mip level and face of the
+
      cube map.</p>
-          <span class="label">Parameters</span>
+
+     
+     <span class="label">Parameters</span>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20px"></td><td><code><span class="label">data</span>:<a href="../../utils/ByteArray.html">ByteArray</a></code> &mdash; a byte array containing the image in the format specified when this CubeTexture object
+
      was created. The ByteArray object must use the little endian format. 
+
      </td>
 </tr>
 <tr>
@@ -569,6 +678,7 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20px"></td><td><code><span class="label">byteArrayOffset</span>:<a href="../../../uint.html">uint</a></code> &mdash; reading of the byte array starts there.
+
      </td>
 </tr>
 <tr>
@@ -576,12 +686,19 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20px"></td><td><code><span class="label">side</span>:<a href="../../../uint.html">uint</a></code> &mdash; A code indicating which side of the cube to upload:  
+
      <p><ul>positive X : 0</ul>
+
         <ul>negative X : 1</ul>
+
         <ul>positive Y : 2</ul>
+
         <ul>negative Y : 3</ul>
+
         <ul>positive Z : 4</ul>
+
         <ul>negative Z : 5</ul></p>    
+
      </td>
 </tr>
 <tr>
@@ -589,8 +706,11 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20px"></td><td><code><span class="label">miplevel</span>:<a href="../../../uint.html">uint</a></code> (default = <code>0</code>)<code></code> &mdash; the mip level to be loaded, level zero is the top-level, 
+
       full-resolution image.
-          </td>
+
+     
+     </td>
 </tr>
 </table>
 <br>
@@ -598,6 +718,7 @@ showHideInherited();
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20"></td><td><code><a href="../../../TypeError.html">TypeError</a> </code> &mdash; Null Pointer Error: when <code>data</code> is null.
+
      </td>
 </tr>
 <tr>
@@ -605,7 +726,9 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../ArgumentError.html">ArgumentError</a> </code> &mdash; Miplevel Too Large: if the specified mip level is greater than that 
+
      implied by the Texture's dimensions.
+
      </td>
 </tr>
 <tr>
@@ -613,8 +736,11 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../RangeError.html">RangeError</a> </code> &mdash; Bad Input Size: if the number of bytes available from <code>byteArrayOffset</code> 
+
      to the end of the <code>data</code> byte array is less than the amount of data required 
+
      for a texture of this mip level or if <code>byteArrayOffset</code> is greater than or equal to the length of <code>data</code>.
+
      </td>
 </tr>
 <tr>
@@ -622,7 +748,9 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../ArgumentError.html">ArgumentError</a> </code> &mdash; Texture Format Mismatch: if the texture format is Context3DTextureFormat.COMPRESSED or 
+
      Context3DTextureFormat.COMPRESSED_ALPHA and the code is executing on a mobile platform where runtime texture compression is not supported.
+
      </td>
 </tr>
 <tr>
@@ -630,10 +758,107 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../Error.html">Error</a> </code> &mdash; 3768: The <code>Stage3D</code> API may not be used during background execution.
-          </td>
+
+     
+     </td>
 </tr>
 </table>
 </div>
+<div class="detailSectionHeader">Event detail</div>
+<a name="event:error"></a>
+<table cellspacing="0" cellpadding="0" class="detailHeader">
+<tr>
+<td class="detailHeaderName">error</td><td class="detailHeaderType">event&nbsp;</td>
+</tr>
+</table>
+<div class="detailBody">
+<span class="label">Event object type: </span><a href="../../events/ErrorEvent.html"><code>flash.events.ErrorEvent</code></a>
+<br>
+<span class="label">ErrorEvent.type property = </span><a href="../../events/ErrorEvent.html#ERROR"><code>flash.events.ErrorEvent.ERROR</code></a>
+<br>
+<p></p>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+ </td>
+</tr>
+</table>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;24
+
+</td>
+</tr>
+</table>
+<p></p><p>
+
+ Dispatched by the CubeTexture object when an asynchronous texture upload
+
+ operation fails in some way. The failure code is provided in the
+
+ <code>errorID</code> field of the error object.
+
+ </p><p>
+	Defines the value of the <code>type</code> property of an <code>error</code> event object. 
+	</p><p>This event has the following properties:</p>
+	<table class="innertable" width="100%">
+	    <tr><th>Property</th><th>Value</th></tr>
+	    <tr><td><code>bubbles</code></td><td><code>false</code></td></tr>
+	    <tr><td><code>cancelable</code></td><td><code>false</code>; there is no default behavior to cancel.</td></tr>
+	    <tr><td><code>currentTarget</code></td><td>The object that is actively processing the Event 
+	object with an event listener.</td></tr>
+	    <tr><td><code>target</code></td><td>The object experiencing a network operation failure.</td></tr>
+	    <tr><td><code>text</code></td><td>Text to be displayed as an error message.</td></tr>
+	 </table>
+	
+	</div>
+<a name="event:textureReady"></a>
+<table cellspacing="0" cellpadding="0" class="detailHeader">
+<tr>
+<td class="detailHeaderName">textureReady</td><td class="detailHeaderType">event&nbsp;</td><td class="detailHeaderRule">&nbsp;</td>
+</tr>
+</table>
+<div class="detailBody">
+<span class="label">Event object type: </span><a href="../../events/Event.html"><code>flash.events.Event</code></a>
+<br>
+<span class="label">Event.type property = </span><a href="../../events/Event.html#TEXTURE_READY"><code>flash.events.Event.TEXTURE_READY</code></a>
+<br>
+<p></p>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+ </td>
+</tr>
+</table>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;24
+
+</td>
+</tr>
+</table>
+<p></p><p>
+
+ Dispatched by the CubeTexture object when an asynchronous texture upload
+
+ operation has completed successfully, and the texture can then be used.
+
+ </p><p>
+	The <code>Event.TEXTURE_READY</code> constant defines the value of the <code>type</code> property of a <code>textureReady</code> event object.
+	
+	This event is dispatched by Texture, RectangleTexture and CubeTexture objects to signal the completion of an asynchronous upload.  Request an
+	asynchronous upload by using the <code>uploadCompressedTextureFromByteArray()</code> method with a <code>true</code>
+	value for the <code>async</code> argument, or using a method such as <code>uploadFromBitmapDataAsync</code> or
+	<code>uploadFromByteArrayAsync</code>.
+	This event neither bubbles nor is cancelable.  
+		</p><p>This event has the following properties:</p>
+		<table class="innertable" width="100%">
+	    <tr><th>Property</th><th>Value</th></tr>
+	    <tr><td><code>bubbles</code></td><td><code>false</code></td></tr>
+	    <tr><td><code>cancelable</code></td><td><code>false</code>; there is no default behavior to cancel.</td></tr>
+	    <tr><td><code>target</code></td><td>The texture object that dispatched this event.</td></tr>
+	 </table>
+        </div>
 <br>
 <br>
 <hr>
@@ -641,11 +866,10 @@ showHideInherited();
 <p></p>
 <div class="feedbackLink">
 <center>
-<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Wed Sep 28 2022, 6:12 PM GMT+01:00) : flash.display3D.textures.CubeTexture">Submit Feedback</a>
+<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Mon Jun 30 2025, 11:00 AM GMT+01:00) : flash.display3D.textures.CubeTexture">Submit Feedback</a>
 </center>
 </div>
-<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Wed Sep 28 2022, 6:12 PM GMT+01:00<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
+<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Mon Jun 30 2025, 11:00 AM GMT+01:00<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
 </div>
 </body>
-</html>
-<!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Wed Sep 28 2022, 6:12 PM GMT+01:00 <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->
+</html><!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Mon Jun 30 2025, 11:00 AM GMT+01:00 <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->

--- a/static/reference/actionscript/3.0/flash/display3D/textures/RectangleTexture.html
+++ b/static/reference/actionscript/3.0/flash/display3D/textures/RectangleTexture.html
@@ -43,11 +43,19 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 </tr>
 </table>
 <p></p>
+
  The Rectangle Texture class represents a 2-dimensional texture uploaded to a rendering context.
-  <p>Defines a 2D texture for use during rendering.</p>
-  <p>Texture cannot be instantiated directly. Create instances by using 
+
+ 
+ <p>Defines a 2D texture for use during rendering.</p>
+
+ 
+ <p>Texture cannot be instantiated directly. Create instances by using 
+
  Context3D <code>createRectangleTexture()</code> method.</p>
-  <p></p>
+
+ 
+ <p></p>
 <p>
 <span class="classHeaderTableLabel">See also</span>
 </p>
@@ -220,6 +228,7 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="#uploadFromBitmapData()">uploadFromBitmapData</a>(source:<a href="../../display/BitmapData.html">BitmapData</a>):<a href="../../../specialTypes.html#void">void</a>
 </div>
 <div class="summaryTableDescription">
+
      Uploads a texture from a BitmapData object.</div>
 </td><td class="summaryTableOwnerCol">RectangleTexture</td>
 </tr>
@@ -229,6 +238,7 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="#uploadFromBitmapDataAsync()">uploadFromBitmapDataAsync</a>(source:<a href="../../display/BitmapData.html">BitmapData</a>):<a href="../../../specialTypes.html#void">void</a>
 </div>
 <div class="summaryTableDescription">
+
      	Uploads a texture from a BitmapData object.</div>
 </td><td class="summaryTableOwnerCol">RectangleTexture</td>
 </tr>
@@ -238,6 +248,7 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="#uploadFromByteArray()">uploadFromByteArray</a>(data:<a href="../../utils/ByteArray.html">ByteArray</a>, byteArrayOffset:<a href="../../../uint.html">uint</a>):<a href="../../../specialTypes.html#void">void</a>
 </div>
 <div class="summaryTableDescription">
+
      Uploads a texture from a ByteArray.</div>
 </td><td class="summaryTableOwnerCol">RectangleTexture</td>
 </tr>
@@ -247,6 +258,7 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="#uploadFromByteArrayAsync()">uploadFromByteArrayAsync</a>(data:<a href="../../utils/ByteArray.html">ByteArray</a>, byteArrayOffset:<a href="../../../uint.html">uint</a>):<a href="../../../specialTypes.html#void">void</a>
 </div>
 <div class="summaryTableDescription">
+
     	Uploads a texture from a ByteArray.</div>
 </td><td class="summaryTableOwnerCol">RectangleTexture</td>
 </tr>
@@ -283,7 +295,7 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a onclick="javascript:setInheritedVisible(true,'Event');" href="#eventSummary" class="showHideLink"><img alt="Show Inherited Events" src="../../../images/collapsed.gif" class="showHideLinkImage"> Show Inherited Events</a>
 </div>
 </div>
-<table id="summaryTableEvent" class="summaryTable hideInheritedEvent" cellpadding="3" cellspacing="0">
+<table id="summaryTableEvent" class="summaryTable " cellpadding="3" cellspacing="0">
 <tr>
 <th>&nbsp;</th><th colspan="2">Event</th><th>Summary</th><th class="summaryTableOwnerCol">Defined&nbsp;by</th>
 </tr>
@@ -305,6 +317,28 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
  [broadcast event] Dispatched when the <span platform="actionscript">Flash Player or</span> AIR application operating
  loses system focus and is becoming inactive.</td><td class="summaryTableOwnerCol"><a href="../../events/EventDispatcher.html">EventDispatcher</a></td>
 </tr>
+<tr class="">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol">
+<div class="summarySignature">
+<a class="signatureLink" href="#event:error">error</a>
+</div>
+</td><td class="summaryTableDescription summaryTableCol">
+
+ Dispatched by the RectangleTexture object when an asynchronous texture upload
+
+ operation fails in some way.</td><td class="summaryTableOwnerCol">RectangleTexture</td>
+</tr>
+<tr class="">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol">
+<div class="summarySignature">
+<a class="signatureLink" href="#event:textureReady">textureReady</a>
+</div>
+</td><td class="summaryTableDescription summaryTableCol">
+
+ Dispatched by the RectangleTexture object when an asynchronous texture upload
+
+ operation has completed successfully, and the texture can then be used.</td><td class="summaryTableOwnerCol">RectangleTexture</td>
+</tr>
 </table>
 </div>
 <script type="text/javascript" language="javascript">
@@ -325,22 +359,29 @@ showHideInherited();
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0     </td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     </td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3.8
+
 </td>
 </tr>
 </table>
 <p></p><p>
+
      Uploads a texture from a BitmapData object.
-          </p><span class="label">Parameters</span>
+
+     
+     </p><span class="label">Parameters</span>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20px"></td><td><code><span class="label">source</span>:<a href="../../display/BitmapData.html">BitmapData</a></code> &mdash; a bitmap.
-          </td>
+
+     
+     </td>
 </tr>
 </table>
 <br>
@@ -348,6 +389,7 @@ showHideInherited();
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20"></td><td><code><a href="../../../TypeError.html">TypeError</a> </code> &mdash; Null Pointer Error: when <code>source</code> is null.
+
      </td>
 </tr>
 <tr>
@@ -355,8 +397,11 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../ArgumentError.html">ArgumentError</a> </code> &mdash; Invalid BitmapData Error: when <code>source</code>  
+
      does not contain a valid texture. The maximum allowed size in any dimension is 4096 or the size
+
      of the backbuffer, whichever is greater.
+
      </td>
 </tr>
 <tr>
@@ -364,7 +409,9 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../Error.html">Error</a> </code> &mdash; 3768: The <code>Stage3D</code> API may not be used during background execution.
-          </td>
+
+     
+     </td>
 </tr>
 </table>
 </div>
@@ -379,27 +426,38 @@ showHideInherited();
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0     	</td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     	</td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;24
+
 	</td>
 </tr>
 </table>
 <p></p><p>
+
      	Uploads a texture from a BitmapData object.
+
      	</p><span class="label">Parameters</span>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20px"></td><td><code><span class="label">source</span>:<a href="../../display/BitmapData.html">BitmapData</a></code> &mdash; a bitmap.
+
      	This function asynchronously uploads texture data.
+
      	Any draw method which attempts to use the texture will fail until the upload completes successfully. 
-	 	Upon successful upload, this <code>Texture</code> object dispatches <code>Event.TEXTURE_UPLOADED</code>.  
-	 	Event.TEXTURE_READY is a callback to indicate that the asynchronous call received for the texture object have been executed successfully.
-	 	Upon any error during the background upload , this <code>Texture</code> object dispatches <code>Event.ERROREVENT</code>.  
-     			</td>
+
+	Upon successful upload, this <code>RectangleTexture</code> object dispatches <code>Event.TEXTURE_READY</code>.
+
+	Event.TEXTURE_READY is a callback to indicate that the asynchronous call received for the texture object have been executed successfully.
+
+	Upon any error during the background upload , this <code>RectangleTexture</code> object dispatches <code>ErrorEvent.ERROR</code>.
+
+	
+	</td>
 </tr>
 </table>
 <br>
@@ -407,6 +465,7 @@ showHideInherited();
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20"></td><td><code><a href="../../../TypeError.html">TypeError</a> </code> &mdash; Null Pointer Error: when <code>source</code> is null.
+
      	</td>
 </tr>
 <tr>
@@ -414,8 +473,11 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../ArgumentError.html">ArgumentError</a> </code> &mdash; Invalid BitmapData Error: when <code>source</code>  
+
      	does not contain a valid texture. The maximum allowed size in any dimension is 4096 or the size
+
      	of the backbuffer, whichever is greater.
+
      	</td>
 </tr>
 <tr>
@@ -423,7 +485,9 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../Error.html">Error</a> </code> &mdash; 3768: The <code>Stage3D</code> API may not be used during background execution.
-     	     	</td>
+
+     	
+     	</td>
 </tr>
 </table>
 <p>
@@ -444,32 +508,44 @@ showHideInherited();
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0     </td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     </td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3.8
+
 </td>
 </tr>
 </table>
 <p></p><p>
+
      Uploads a texture from a ByteArray.
-          </p><span class="label">Parameters</span>
+
+     
+     </p><span class="label">Parameters</span>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20px"></td><td><code><span class="label">data</span>:<a href="../../utils/ByteArray.html">ByteArray</a></code> &mdash; a byte array that is contains enough bytes in the textures internal format to fill the texture.  
+
                      rgba textures are read as bytes per texel component (1 or 4).
+
                      float textures are read as floats per texel component (1 or 4).
+
      The ByteArray object must use the little endian format.
-          </td>
+
+     
+     </td>
 </tr>
 <tr>
 <td class="paramSpacer">&nbsp;</td>
 </tr>
 <tr>
 <td width="20px"></td><td><code><span class="label">byteArrayOffset</span>:<a href="../../../uint.html">uint</a></code> &mdash; the position in the byte array object at which to start reading the texture data.
-          </td>
+
+     
+     </td>
 </tr>
 </table>
 <br>
@@ -477,6 +553,7 @@ showHideInherited();
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20"></td><td><code><a href="../../../TypeError.html">TypeError</a> </code> &mdash; Null Pointer Error: when <code>data</code> is null.
+
      </td>
 </tr>
 <tr>
@@ -484,8 +561,11 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../RangeError.html">RangeError</a> </code> &mdash; Bad Input Size: if the number of bytes available from <code>byteArrayOffset</code> 
+
      to the end of <code>data</code> byte array is less than the amount of data required for a texture, or if <code>byteArrayOffset</code>
+
 	 is greater than or equal to the length of <code>data</code>. 
+
      </td>
 </tr>
 <tr>
@@ -493,7 +573,9 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../Error.html">Error</a> </code> &mdash; 3768: The <code>Stage3D</code> API may not be used during background execution.
+
       
+
      </td>
 </tr>
 </table>
@@ -509,36 +591,53 @@ showHideInherited();
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0     	</td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     	</td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;24
+
 	</td>
 </tr>
 </table>
 <p></p><p>
+
     	Uploads a texture from a ByteArray.
-     	     	</p><span class="label">Parameters</span>
+
+     	
+     	</p><span class="label">Parameters</span>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20px"></td><td><code><span class="label">data</span>:<a href="../../utils/ByteArray.html">ByteArray</a></code> &mdash; a byte array that is contains enough bytes in the textures internal format to fill the texture.  
+
     	                rgba textures are read as bytes per texel component (1 or 4).
+
      	                float textures are read as floats per texel component (1 or 4).
+
 		The ByteArray object must use the little endian format.
-     	     	</td>
+
+     	
+     	</td>
 </tr>
 <tr>
 <td class="paramSpacer">&nbsp;</td>
 </tr>
 <tr>
 <td width="20px"></td><td><code><span class="label">byteArrayOffset</span>:<a href="../../../uint.html">uint</a></code> &mdash; the position in the byte array object at which to start reading the texture data.
-     	     	 This function asynchronously uploads texture data.
-	 	 Any draw method which attempts to use the texture will fail until the upload completes successfully.  
-	 	 Upon successful upload, this <code>Texture</code> object dispatches <code>Event.TEXTURE_UPLOADED</code>.  
-	 	 Event.TEXTURE_READY is a callback to indicate that the asynchronous call received for the texture object have been executed successfully.
-	 	 Upon any error during the background upload , this <code>Texture</code> object dispatches <code>Event.ERROREVENT</code>.  
+
+     	
+     	 This function asynchronously uploads texture data.
+
+	 Any draw method which attempts to use the texture will fail until the upload completes successfully.  
+
+	 Upon successful upload, this <code>RectangleTexture</code> object dispatches <code>Event.TEXTURE_READY</code>.
+
+	 Event.TEXTURE_READY is a callback to indicate that the asynchronous call received for the texture object have been executed successfully.
+
+	 Upon any error during the background upload , this <code>RectangleTexture</code> object dispatches <code>ErrorEvent.ERROR</code>.
+
      	</td>
 </tr>
 </table>
@@ -547,6 +646,7 @@ showHideInherited();
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20"></td><td><code><a href="../../../TypeError.html">TypeError</a> </code> &mdash; Null Pointer Error: when <code>data</code> is null.
+
      	</td>
 </tr>
 <tr>
@@ -554,8 +654,11 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../RangeError.html">RangeError</a> </code> &mdash; Bad Input Size: if the number of bytes available from <code>byteArrayOffset</code> 
+
      	to the end of <code>data</code> byte array is less than the amount of data required for a texture, or if <code>byteArrayOffset</code>
-	 	is greater than or equal to the length of <code>data</code>. 
+
+	is greater than or equal to the length of <code>data</code>. 
+
      	</td>
 </tr>
 <tr>
@@ -563,11 +666,108 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../Error.html">Error</a> </code> &mdash; 3768: The <code>Stage3D</code> API may not be used during background execution.
+
      	 
+
      	</td>
 </tr>
 </table>
 </div>
+<div class="detailSectionHeader">Event detail</div>
+<a name="event:error"></a>
+<table cellspacing="0" cellpadding="0" class="detailHeader">
+<tr>
+<td class="detailHeaderName">error</td><td class="detailHeaderType">event&nbsp;</td>
+</tr>
+</table>
+<div class="detailBody">
+<span class="label">Event object type: </span><a href="../../events/ErrorEvent.html"><code>flash.events.ErrorEvent</code></a>
+<br>
+<span class="label">ErrorEvent.type property = </span><a href="../../events/ErrorEvent.html#ERROR"><code>flash.events.ErrorEvent.ERROR</code></a>
+<br>
+<p></p>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+ </td>
+</tr>
+</table>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;24
+
+</td>
+</tr>
+</table>
+<p></p><p>
+
+ Dispatched by the RectangleTexture object when an asynchronous texture upload
+
+ operation fails in some way. The failure code is provided in the
+
+ <code>errorID</code> field of the error object.
+
+ </p><p>
+	Defines the value of the <code>type</code> property of an <code>error</code> event object. 
+	</p><p>This event has the following properties:</p>
+	<table class="innertable" width="100%">
+	    <tr><th>Property</th><th>Value</th></tr>
+	    <tr><td><code>bubbles</code></td><td><code>false</code></td></tr>
+	    <tr><td><code>cancelable</code></td><td><code>false</code>; there is no default behavior to cancel.</td></tr>
+	    <tr><td><code>currentTarget</code></td><td>The object that is actively processing the Event 
+	object with an event listener.</td></tr>
+	    <tr><td><code>target</code></td><td>The object experiencing a network operation failure.</td></tr>
+	    <tr><td><code>text</code></td><td>Text to be displayed as an error message.</td></tr>
+	 </table>
+	
+	</div>
+<a name="event:textureReady"></a>
+<table cellspacing="0" cellpadding="0" class="detailHeader">
+<tr>
+<td class="detailHeaderName">textureReady</td><td class="detailHeaderType">event&nbsp;</td><td class="detailHeaderRule">&nbsp;</td>
+</tr>
+</table>
+<div class="detailBody">
+<span class="label">Event object type: </span><a href="../../events/Event.html"><code>flash.events.Event</code></a>
+<br>
+<span class="label">Event.type property = </span><a href="../../events/Event.html#TEXTURE_READY"><code>flash.events.Event.TEXTURE_READY</code></a>
+<br>
+<p></p>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+ </td>
+</tr>
+</table>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;24
+
+</td>
+</tr>
+</table>
+<p></p><p>
+
+ Dispatched by the RectangleTexture object when an asynchronous texture upload
+
+ operation has completed successfully, and the texture can then be used.
+
+ </p><p>
+	The <code>Event.TEXTURE_READY</code> constant defines the value of the <code>type</code> property of a <code>textureReady</code> event object.
+	
+	This event is dispatched by Texture, RectangleTexture and CubeTexture objects to signal the completion of an asynchronous upload.  Request an
+	asynchronous upload by using the <code>uploadCompressedTextureFromByteArray()</code> method with a <code>true</code>
+	value for the <code>async</code> argument, or using a method such as <code>uploadFromBitmapDataAsync</code> or
+	<code>uploadFromByteArrayAsync</code>.
+	This event neither bubbles nor is cancelable.  
+		</p><p>This event has the following properties:</p>
+		<table class="innertable" width="100%">
+	    <tr><th>Property</th><th>Value</th></tr>
+	    <tr><td><code>bubbles</code></td><td><code>false</code></td></tr>
+	    <tr><td><code>cancelable</code></td><td><code>false</code>; there is no default behavior to cancel.</td></tr>
+	    <tr><td><code>target</code></td><td>The texture object that dispatched this event.</td></tr>
+	 </table>
+        </div>
 <br>
 <br>
 <hr>
@@ -575,11 +775,10 @@ showHideInherited();
 <p></p>
 <div class="feedbackLink">
 <center>
-<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Wed Sep 28 2022, 6:12 PM GMT+01:00) : flash.display3D.textures.RectangleTexture">Submit Feedback</a>
+<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Mon Jun 30 2025, 11:00 AM GMT+01:00) : flash.display3D.textures.RectangleTexture">Submit Feedback</a>
 </center>
 </div>
-<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Wed Sep 28 2022, 6:12 PM GMT+01:00<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
+<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Mon Jun 30 2025, 11:00 AM GMT+01:00<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
 </div>
 </body>
-</html>
-<!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Wed Sep 28 2022, 6:12 PM GMT+01:00 <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->
+</html><!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Mon Jun 30 2025, 11:00 AM GMT+01:00 <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->

--- a/static/reference/actionscript/3.0/flash/display3D/textures/Texture.html
+++ b/static/reference/actionscript/3.0/flash/display3D/textures/Texture.html
@@ -43,11 +43,19 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 </tr>
 </table>
 <p></p>
+
  The Texture class represents a 2-dimensional texture uploaded to a rendering context.
-  <p>Defines a 2D texture for use during rendering.</p>
-  <p>Texture cannot be instantiated directly. Create instances by using 
+
+ 
+ <p>Defines a 2D texture for use during rendering.</p>
+
+ 
+ <p>Texture cannot be instantiated directly. Create instances by using 
+
  Context3D <code>createTexture()</code> method.</p>
-  <p></p>
+
+ 
+ <p></p>
 <p>
 <span class="classHeaderTableLabel">See also</span>
 </p>
@@ -220,6 +228,7 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="#uploadCompressedTextureFromByteArray()">uploadCompressedTextureFromByteArray</a>(data:<a href="../../utils/ByteArray.html">ByteArray</a>, byteArrayOffset:<a href="../../../uint.html">uint</a>, async:<a href="../../../Boolean.html">Boolean</a> = false):<a href="../../../specialTypes.html#void">void</a>
 </div>
 <div class="summaryTableDescription">
+
      Uploads a compressed texture in Adobe Texture Format (ATF) from a ByteArray object.</div>
 </td><td class="summaryTableOwnerCol">Texture</td>
 </tr>
@@ -229,6 +238,7 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="#uploadFromBitmapData()">uploadFromBitmapData</a>(source:<a href="../../display/BitmapData.html">BitmapData</a>, miplevel:<a href="../../../uint.html">uint</a> = 0):<a href="../../../specialTypes.html#void">void</a>
 </div>
 <div class="summaryTableDescription">
+
      Uploads a texture from a BitmapData object.</div>
 </td><td class="summaryTableOwnerCol">Texture</td>
 </tr>
@@ -238,6 +248,7 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="#uploadFromBitmapDataAsync()">uploadFromBitmapDataAsync</a>(source:<a href="../../display/BitmapData.html">BitmapData</a>, miplevel:<a href="../../../uint.html">uint</a> = 0):<a href="../../../specialTypes.html#void">void</a>
 </div>
 <div class="summaryTableDescription">
+
 		Uploads miplevel 0 for a texture from a BitmapData object asynchronously.</div>
 </td><td class="summaryTableOwnerCol">Texture</td>
 </tr>
@@ -247,6 +258,7 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="#uploadFromByteArray()">uploadFromByteArray</a>(data:<a href="../../utils/ByteArray.html">ByteArray</a>, byteArrayOffset:<a href="../../../uint.html">uint</a>, miplevel:<a href="../../../uint.html">uint</a> = 0):<a href="../../../specialTypes.html#void">void</a>
 </div>
 <div class="summaryTableDescription">
+
      Uploads a texture from a ByteArray.</div>
 </td><td class="summaryTableOwnerCol">Texture</td>
 </tr>
@@ -256,6 +268,7 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="#uploadFromByteArrayAsync()">uploadFromByteArrayAsync</a>(data:<a href="../../utils/ByteArray.html">ByteArray</a>, byteArrayOffset:<a href="../../../uint.html">uint</a>, miplevel:<a href="../../../uint.html">uint</a> = 0):<a href="../../../specialTypes.html#void">void</a>
 </div>
 <div class="summaryTableDescription">
+
 		Uploads miplevel 0 for a texture from a ByteArray asynchronously.</div>
 </td><td class="summaryTableOwnerCol">Texture</td>
 </tr>
@@ -292,7 +305,7 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a onclick="javascript:setInheritedVisible(true,'Event');" href="#eventSummary" class="showHideLink"><img alt="Show Inherited Events" src="../../../images/collapsed.gif" class="showHideLinkImage"> Show Inherited Events</a>
 </div>
 </div>
-<table id="summaryTableEvent" class="summaryTable hideInheritedEvent" cellpadding="3" cellspacing="0">
+<table id="summaryTableEvent" class="summaryTable " cellpadding="3" cellspacing="0">
 <tr>
 <th>&nbsp;</th><th colspan="2">Event</th><th>Summary</th><th class="summaryTableOwnerCol">Defined&nbsp;by</th>
 </tr>
@@ -314,6 +327,28 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
  [broadcast event] Dispatched when the <span platform="actionscript">Flash Player or</span> AIR application operating
  loses system focus and is becoming inactive.</td><td class="summaryTableOwnerCol"><a href="../../events/EventDispatcher.html">EventDispatcher</a></td>
 </tr>
+<tr class="">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol">
+<div class="summarySignature">
+<a class="signatureLink" href="#event:error">error</a>
+</div>
+</td><td class="summaryTableDescription summaryTableCol">
+
+ Dispatched by the Texture object when an asynchronous texture upload
+
+ operation fails in some way.</td><td class="summaryTableOwnerCol">Texture</td>
+</tr>
+<tr class="">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol">
+<div class="summarySignature">
+<a class="signatureLink" href="#event:textureReady">textureReady</a>
+</div>
+</td><td class="summaryTableDescription summaryTableCol">
+
+ Dispatched by the Texture object when an asynchronous texture upload
+
+ operation has completed successfully, and the texture can then be used.</td><td class="summaryTableOwnerCol">Texture</td>
+</tr>
 </table>
 </div>
 <script type="text/javascript" language="javascript">
@@ -334,26 +369,37 @@ showHideInherited();
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0     </td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     </td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3
+
 </td>
 </tr>
 </table>
 <p></p><p>
+
      Uploads a compressed texture in Adobe Texture Format (ATF) from a ByteArray object.
+
 	 ATF file version 2 requires SWF version 21 or newer and ATF file version 3 requires SWF version 29 or newer.
+
 	 For ATF files created with png image without alpha the <code>format</code> string given during <code>Context3DObject::createTexture</code>
+
 	 should be "COMPRESSED" and for ATF files created with png image with alpha the <code>format</code> string given during 
+
 	 <code>Context3DObject::createTexture</code> should be "COMPRESSED_ALPHA".
-          </p><span class="label">Parameters</span>
+
+     
+     </p><span class="label">Parameters</span>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20px"></td><td><code><span class="label">data</span>:<a href="../../utils/ByteArray.html">ByteArray</a></code> &mdash; a byte array that contains a compressed texture 
+
      including mipmaps. The ByteArray object must use the little endian format.
+
      </td>
 </tr>
 <tr>
@@ -361,6 +407,7 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20px"></td><td><code><span class="label">byteArrayOffset</span>:<a href="../../../uint.html">uint</a></code> &mdash; the position in the byte array at which to start reading the texture data.
+
 	 </td>
 </tr>
 <tr>
@@ -368,10 +415,15 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20px"></td><td><code><span class="label">async</span>:<a href="../../../Boolean.html">Boolean</a></code> (default = <code>false</code>)<code></code> &mdash;  If true, this function returns immediately.  Any draw method
+
 	 which attempts to use the texture will fail until the upload completes successfully.  Upon successful
-	 upload, this <code>CubeTexture</code> object dispatches <code>Event.TEXTURE_READY</code>.  
+
+	 upload, this <code>Texture</code> object dispatches <code>Event.TEXTURE_READY</code>.
+
 	 Default value: false.  
-     	 </td>
+
+     
+	 </td>
 </tr>
 </table>
 <br>
@@ -379,6 +431,7 @@ showHideInherited();
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20"></td><td><code><a href="../../../TypeError.html">TypeError</a> </code> &mdash; Null Pointer Error: when <code>data</code> is null.
+
      </td>
 </tr>
 <tr>
@@ -386,8 +439,11 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../ArgumentError.html">ArgumentError</a> </code> &mdash; Texture Decoding Failed: when the compression format of this object cannot be 
+
      derived from the format of the compressed data in <code>data</code> or when the SWF version is
+
 	 incompatible with the ATF file version.
+
      </td>
 </tr>
 <tr>
@@ -395,7 +451,9 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../ArgumentError.html">ArgumentError</a> </code> &mdash; Texture Size Does Not Match: when the width and height of the decompressed 
+
      texture do not equal the dimensions of this Texture object.
+
      </td>
 </tr>
 <tr>
@@ -403,7 +461,9 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../ArgumentError.html">ArgumentError</a> </code> &mdash; Miplevel Too Large: if the mip level of the decompressed texture is greater 
+
      than that implied by the size of the texture.
+
      </td>
 </tr>
 <tr>
@@ -411,7 +471,9 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../ArgumentError.html">ArgumentError</a> </code> &mdash; Texture Format Mismatch: if the decoded ATF bytes don't contain a texture  
+
      compatible with this texture's format.
+
      </td>
 </tr>
 <tr>
@@ -419,6 +481,7 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../Error.html">Error</a> </code> &mdash; 3768: The <code>Stage3D</code> API may not be used during background execution.
+
 	 </td>
 </tr>
 <tr>
@@ -426,10 +489,15 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../RangeError.html">RangeError</a> </code> &mdash; Bad Input Size: when there is integer overflow of <code>byteArrayOffset</code> or 
+
 	  if <code>byteArrayOffset</code> + 6 is greater than the length of <code>data</code>, or if the 
+
 	  number of bytes available from <code>byteArrayOffset</code> to the end of the <code>data</code> byte array
+
 	  is less than the amount of data required for ATF texture.
+
      
+
      </td>
 </tr>
 </table>
@@ -451,21 +519,27 @@ showHideInherited();
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0     </td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     </td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3
+
 </td>
 </tr>
 </table>
 <p></p><p>
+
      Uploads a texture from a BitmapData object.
-          </p><span class="label">Parameters</span>
+
+     
+     </p><span class="label">Parameters</span>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20px"></td><td><code><span class="label">source</span>:<a href="../../display/BitmapData.html">BitmapData</a></code> &mdash; a bitmap.
+
      </td>
 </tr>
 <tr>
@@ -473,8 +547,11 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20px"></td><td><code><span class="label">miplevel</span>:<a href="../../../uint.html">uint</a></code> (default = <code>0</code>)<code></code> &mdash; the mip level to be loaded, level zero being the top-level 
+
       full-resolution image.
-          </td>
+
+     
+     </td>
 </tr>
 </table>
 <br>
@@ -482,6 +559,7 @@ showHideInherited();
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20"></td><td><code><a href="../../../TypeError.html">TypeError</a> </code> &mdash; Null Pointer Error: when <code>source</code> is null.
+
      </td>
 </tr>
 <tr>
@@ -489,7 +567,9 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../ArgumentError.html">ArgumentError</a> </code> &mdash; Miplevel Too Large: if the specified mip level is greater than that 
+
      implied by the larger of the Texture's dimensions.
+
      </td>
 </tr>
 <tr>
@@ -497,8 +577,11 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../ArgumentError.html">ArgumentError</a> </code> &mdash; Invalid BitmapData Error: if <code>source</code> if the BitmapData 
+
      object does not contain a valid cube texture face. The image must have sides
+
      equal to a power of two, and the correct size for the miplevel specified.    
+
      </td>
 </tr>
 <tr>
@@ -506,7 +589,9 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../ArgumentError.html">ArgumentError</a> </code> &mdash; Texture Format Mismatch: if the texture format is Context3DTextureFormat.COMPRESSED or 
+
      Context3DTextureFormat.COMPRESSED_ALPHA and the code is executing on a mobile platform where runtime texture compression is not supported.
+
      </td>
 </tr>
 <tr>
@@ -514,7 +599,9 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../Error.html">Error</a> </code> &mdash; 3768: The <code>Stage3D</code> API may not be used during background execution.
+
      
+
      </td>
 </tr>
 </table>
@@ -530,25 +617,35 @@ showHideInherited();
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0		</td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+		</td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;24
+
 		</td>
 </tr>
 </table>
 <p></p><p>
+
 		Uploads miplevel 0 for a texture from a BitmapData object asynchronously.
+
 		Any draw method which attempts to use the texture fails until the upload completes successfully.  
+
 		Upon successful upload, this <code>Texture</code> object dispatches <code>Event.TEXTURE_READY</code>.  
+
 		Event.TEXTURE_READY is a callback to indicate that the asynchronous call received for the texture object have been executed successfully.
-		Upon any error during the background upload , this <code>Texture</code> object dispatches <code>Event.ERROREVENT</code>.
-				</p><span class="label">Parameters</span>
+
+		Upon any error during the background upload , this <code>Texture</code> object dispatches <code>ErrorEvent.ERROR</code>.
+
+		
+		</p><span class="label">Parameters</span>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20px"></td><td><code><span class="label">source</span>:<a href="../../display/BitmapData.html">BitmapData</a></code> &mdash; a bitmap  
+
 		</td>
 </tr>
 <tr>
@@ -563,6 +660,7 @@ showHideInherited();
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20"></td><td><code><a href="../../../TypeError.html">TypeError</a> </code> &mdash; Null Pointer Error: when <code>source</code> is null.
+
 		</td>
 </tr>
 <tr>
@@ -570,8 +668,11 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../ArgumentError.html">ArgumentError</a> </code> &mdash; Invalid BitmapData Error: if <code>source</code> if the BitmapData 
+
 		object does not contain a valid texture. The image must be
+
 		equal to a power of two, and the correct size for the miplevel specified.    
+
 		</td>
 </tr>
 <tr>
@@ -579,7 +680,9 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../ArgumentError.html">ArgumentError</a> </code> &mdash; Texture Format Mismatch: if the texture format is Context3DTextureFormat.COMPRESSED or 
+
 		Context3DTextureFormat.COMPRESSED_ALPHA and the code is executing on a mobile platform where runtime texture compression is not supported.
+
 		</td>
 </tr>
 <tr>
@@ -587,6 +690,7 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../ArgumentError.html">ArgumentError</a> </code> &mdash; Asynchronous upload supported for miplevel 0 only.
+
 		</td>
 </tr>
 <tr>
@@ -594,6 +698,7 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../Error.html">Error</a> </code> &mdash; 3768: The <code>Stage3D</code> API may not be used during background execution.
+
 		</td>
 </tr>
 </table>
@@ -615,31 +720,42 @@ showHideInherited();
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0     </td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+     </td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3
+
 </td>
 </tr>
 </table>
 <p></p><p>
+
      Uploads a texture from a ByteArray.
-          </p><span class="label">Parameters</span>
+
+     
+     </p><span class="label">Parameters</span>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20px"></td><td><code><span class="label">data</span>:<a href="../../utils/ByteArray.html">ByteArray</a></code> &mdash; a byte array that is contains enough bytes in the textures internal format to fill the texture.  
+
                      rgba textures are read as bytes per texel component (1 or 4).
+
                      float textures are read as floats per texel component (1 or 4).
+
      The ByteArray object must use the little endian format.
-          </td>
+
+     
+     </td>
 </tr>
 <tr>
 <td class="paramSpacer">&nbsp;</td>
 </tr>
 <tr>
 <td width="20px"></td><td><code><span class="label">byteArrayOffset</span>:<a href="../../../uint.html">uint</a></code> &mdash; the position in the byte array object at which to start reading the texture data.
+
      </td>
 </tr>
 <tr>
@@ -647,8 +763,11 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20px"></td><td><code><span class="label">miplevel</span>:<a href="../../../uint.html">uint</a></code> (default = <code>0</code>)<code></code> &mdash; the mip level to be loaded, level zero is the top-level, 
+
       full-resolution image.
-          </td>
+
+     
+     </td>
 </tr>
 </table>
 <br>
@@ -656,6 +775,7 @@ showHideInherited();
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20"></td><td><code><a href="../../../TypeError.html">TypeError</a> </code> &mdash; Null Pointer Error: when <code>data</code> is null.
+
      </td>
 </tr>
 <tr>
@@ -663,7 +783,9 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../ArgumentError.html">ArgumentError</a> </code> &mdash; Miplevel Too Large: if the specified mip level is greater than 
+
      that implied by the larger of the Texture's dimensions.
+
      </td>
 </tr>
 <tr>
@@ -671,8 +793,11 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../RangeError.html">RangeError</a> </code> &mdash; Bad Input Size: if the number of bytes available from <code>byteArrayOffset</code> 
+
      to the end of the <code>data</code> byte array is less than the amount of data required 
+
      for a texture of this mip level or if <code>byteArrayOffset</code> is greater than or equal to the length of <code>data</code>. 
+
      </td>
 </tr>
 <tr>
@@ -680,7 +805,9 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../ArgumentError.html">ArgumentError</a> </code> &mdash; Texture Format Mismatch: if the texture format is Context3DTextureFormat.COMPRESSED or 
+
      Context3DTextureFormat.COMPRESSED_ALPHA and the code is executing on a mobile platform where runtime texture compression is not supported.
+
      </td>
 </tr>
 <tr>
@@ -688,7 +815,9 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../Error.html">Error</a> </code> &mdash; 3768: The <code>Stage3D</code> API may not be used during background execution.
+
       
+
      </td>
 </tr>
 </table>
@@ -704,35 +833,50 @@ showHideInherited();
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0		</td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+		</td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;24
+
 		</td>
 </tr>
 </table>
 <p></p><p>
+
 		Uploads miplevel 0 for a texture from a ByteArray asynchronously.
+
 		Any draw method which attempts to use the texture fails until the upload completes successfully.  
+
 		Upon successful upload, this <code>Texture</code> object dispatches <code>Event.TEXTURE_READY</code>.  
+
 		Event.TEXTURE_READY is a callback to indicate that the asynchronous calls received for the texture object have been executed successfully.
-		Upon any error during the background upload, this <code>Texture</code> object dispatches <code>Event.ERROREVENT</code>.
-				</p><span class="label">Parameters</span>
+
+		Upon any error during the background upload, this <code>Texture</code> object dispatches <code>ErrorEvent.ERROR</code>.
+
+		
+		</p><span class="label">Parameters</span>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20px"></td><td><code><span class="label">data</span>:<a href="../../utils/ByteArray.html">ByteArray</a></code> &mdash; a byte array that contains enough bytes in the textures internal format to fill the texture.  
+
 		                rgba textures are read as bytes per texel component (1 or 4).
+
 		                float textures are read as floats per texel component (1 or 4).
+
 		The ByteArray object must use the little endian format.
-				</td>
+
+		
+		</td>
 </tr>
 <tr>
 <td class="paramSpacer">&nbsp;</td>
 </tr>
 <tr>
 <td width="20px"></td><td><code><span class="label">byteArrayOffset</span>:<a href="../../../uint.html">uint</a></code> &mdash; the position in the byte array object at which to start reading the texture data.  
+
 		</td>
 </tr>
 <tr>
@@ -747,6 +891,7 @@ showHideInherited();
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20"></td><td><code><a href="../../../TypeError.html">TypeError</a> </code> &mdash; Null Pointer Error: when <code>data</code> is null.
+
 		</td>
 </tr>
 <tr>
@@ -754,8 +899,11 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../RangeError.html">RangeError</a> </code> &mdash; Bad Input Size: if the number of bytes available from <code>byteArrayOffset</code> 
+
 		to the end of the <code>data</code> byte array is less than the amount of data required 
+
 		for a texture of mip level 0 or if <code>byteArrayOffset</code> is greater than or equal to the length of <code>data</code>. 
+
 		</td>
 </tr>
 <tr>
@@ -763,7 +911,9 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../ArgumentError.html">ArgumentError</a> </code> &mdash; Texture Format Mismatch: if the texture format is Context3DTextureFormat.COMPRESSED or 
+
 		Context3DTextureFormat.COMPRESSED_ALPHA and the code is executing on a mobile platform where runtime texture compression is not supported.
+
 		</td>
 </tr>
 <tr>
@@ -771,6 +921,7 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../ArgumentError.html">ArgumentError</a> </code> &mdash; Asynchronous upload supported for miplevel 0 only.
+
 		</td>
 </tr>
 <tr>
@@ -778,6 +929,7 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../Error.html">Error</a> </code> &mdash; 3768: The <code>Stage3D</code> API may not be used during background execution.
+
 		</td>
 </tr>
 <tr>
@@ -785,6 +937,8 @@ showHideInherited();
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../../Error.html">Error</a> </code> &mdash; if an async upload has been initiated on a texture object and there is another asynchronous upload call on the same texture object.
+
+
 
 		</td>
 </tr>
@@ -796,6 +950,101 @@ showHideInherited();
 <a href="../../events/Event.html#TEXTURE_READY" target="">flash.events.Event.TEXTURE_READY</a>
 </div>
 </div>
+<div class="detailSectionHeader">Event detail</div>
+<a name="event:error"></a>
+<table cellspacing="0" cellpadding="0" class="detailHeader">
+<tr>
+<td class="detailHeaderName">error</td><td class="detailHeaderType">event&nbsp;</td>
+</tr>
+</table>
+<div class="detailBody">
+<span class="label">Event object type: </span><a href="../../events/ErrorEvent.html"><code>flash.events.ErrorEvent</code></a>
+<br>
+<span class="label">ErrorEvent.type property = </span><a href="../../events/ErrorEvent.html#ERROR"><code>flash.events.ErrorEvent.ERROR</code></a>
+<br>
+<p></p>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+ </td>
+</tr>
+</table>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;24
+
+</td>
+</tr>
+</table>
+<p></p><p>
+
+ Dispatched by the Texture object when an asynchronous texture upload
+
+ operation fails in some way. The failure code is provided in the
+
+ <code>errorID</code> field of the error object.
+
+ </p><p>
+	Defines the value of the <code>type</code> property of an <code>error</code> event object. 
+	</p><p>This event has the following properties:</p>
+	<table class="innertable" width="100%">
+	    <tr><th>Property</th><th>Value</th></tr>
+	    <tr><td><code>bubbles</code></td><td><code>false</code></td></tr>
+	    <tr><td><code>cancelable</code></td><td><code>false</code>; there is no default behavior to cancel.</td></tr>
+	    <tr><td><code>currentTarget</code></td><td>The object that is actively processing the Event 
+	object with an event listener.</td></tr>
+	    <tr><td><code>target</code></td><td>The object experiencing a network operation failure.</td></tr>
+	    <tr><td><code>text</code></td><td>Text to be displayed as an error message.</td></tr>
+	 </table>
+	
+	</div>
+<a name="event:textureReady"></a>
+<table cellspacing="0" cellpadding="0" class="detailHeader">
+<tr>
+<td class="detailHeaderName">textureReady</td><td class="detailHeaderType">event&nbsp;</td><td class="detailHeaderRule">&nbsp;</td>
+</tr>
+</table>
+<div class="detailBody">
+<span class="label">Event object type: </span><a href="../../events/Event.html"><code>flash.events.Event</code></a>
+<br>
+<span class="label">Event.type property = </span><a href="../../events/Event.html#TEXTURE_READY"><code>flash.events.Event.TEXTURE_READY</code></a>
+<br>
+<p></p>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+ </td>
+</tr>
+</table>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;24
+
+</td>
+</tr>
+</table>
+<p></p><p>
+
+ Dispatched by the Texture object when an asynchronous texture upload
+
+ operation has completed successfully, and the texture can then be used.
+
+ </p><p>
+	The <code>Event.TEXTURE_READY</code> constant defines the value of the <code>type</code> property of a <code>textureReady</code> event object.
+	
+	This event is dispatched by Texture, RectangleTexture and CubeTexture objects to signal the completion of an asynchronous upload.  Request an
+	asynchronous upload by using the <code>uploadCompressedTextureFromByteArray()</code> method with a <code>true</code>
+	value for the <code>async</code> argument, or using a method such as <code>uploadFromBitmapDataAsync</code> or
+	<code>uploadFromByteArrayAsync</code>.
+	This event neither bubbles nor is cancelable.  
+		</p><p>This event has the following properties:</p>
+		<table class="innertable" width="100%">
+	    <tr><th>Property</th><th>Value</th></tr>
+	    <tr><td><code>bubbles</code></td><td><code>false</code></td></tr>
+	    <tr><td><code>cancelable</code></td><td><code>false</code>; there is no default behavior to cancel.</td></tr>
+	    <tr><td><code>target</code></td><td>The texture object that dispatched this event.</td></tr>
+	 </table>
+        </div>
 <br>
 <br>
 <hr>
@@ -803,11 +1052,10 @@ showHideInherited();
 <p></p>
 <div class="feedbackLink">
 <center>
-<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Wed Sep 28 2022, 6:12 PM GMT+01:00) : flash.display3D.textures.Texture">Submit Feedback</a>
+<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Mon Jun 30 2025, 11:00 AM GMT+01:00) : flash.display3D.textures.Texture">Submit Feedback</a>
 </center>
 </div>
-<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Wed Sep 28 2022, 6:12 PM GMT+01:00<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
+<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Mon Jun 30 2025, 11:00 AM GMT+01:00<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
 </div>
 </body>
-</html>
-<!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Wed Sep 28 2022, 6:12 PM GMT+01:00 <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->
+</html><!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Mon Jun 30 2025, 11:00 AM GMT+01:00 <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->

--- a/static/reference/actionscript/3.0/flash/events/Event.html
+++ b/static/reference/actionscript/3.0/flash/events/Event.html
@@ -3365,8 +3365,7 @@ showHideInherited();
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0	
-	</td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0		</td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
@@ -3378,14 +3377,28 @@ showHideInherited();
 <p></p><p>
 	The <code>Event.TEXTURE_READY</code> constant defines the value of the <code>type</code> property of a <code>textureReady</code> event object.
 	
-	This event is dispatched by Texture and CubeTexture objects to signal the completion of an asynchronous upload.  Request an
-	asynchronous upload by using the <code>uploadCompressedTextureFromByteArray()</code> method on Texture or CubeTexture.
+	This event is dispatched by Texture, RectangleTexture and CubeTexture objects to signal the completion of an asynchronous upload.  Request an
+	asynchronous upload by using the <code>uploadCompressedTextureFromByteArray()</code> method with a <code>true</code>
+	value for the <code>async</code> argument, or using a method such as <code>uploadFromBitmapDataAsync</code> or
+	<code>uploadFromByteArrayAsync</code>.
 	This event neither bubbles nor is cancelable.  
-	 
-        </p><p>
+		</p><p>This event has the following properties:</p>
+		<table class="innertable" width="100%">
+	    <tr><th>Property</th><th>Value</th></tr>
+	    <tr><td><code>bubbles</code></td><td><code>false</code></td></tr>
+	    <tr><td><code>cancelable</code></td><td><code>false</code>; there is no default behavior to cancel.</td></tr>
+	    <tr><td><code>target</code></td><td>The texture object that dispatched this event.</td></tr>
+	 </table>
+        <p>
 <span class="label">See also</span>
 </p>
-<div class="seeAlso">Texture.uploadCompressedTextureFromByteArray()<br>CubeTexture.uploadCompressedTextureFromByteArray()</div>
+<div class="seeAlso">
+<a href="../display3D/textures/Texture.html#uploadCompressedTextureFromByteArray()" target="">flash.display3D.textures.Texture.uploadCompressedTextureFromByteArray()</a>
+<br>
+<a href="../display3D/textures/CubeTexture.html#uploadCompressedTextureFromByteArray()" target="">flash.display3D.textures.CubeTexture.uploadCompressedTextureFromByteArray()</a>
+<br>
+<a href="../display3D/textures/RectangleTexture.html#uploadFromBitmapDataAsync()" target="">flash.display3D.textures.RectangleTexture.uploadFromBitmapDataAsync()</a>
+</div>
 </div>
 <a name="UNLOAD"></a>
 <table cellspacing="0" cellpadding="0" class="detailHeader">
@@ -3733,10 +3746,10 @@ class Square extends Sprite {
 <p></p>
 <div class="feedbackLink">
 <center>
-<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Thu Feb 27 2025, 6:06 AM GMT) : flash.events.Event">Submit Feedback</a>
+<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Mon Jun 30 2025, 11:00 AM GMT+01:00) : flash.events.Event">Submit Feedback</a>
 </center>
 </div>
-<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Thu Feb 27 2025, 6:06 AM GMT<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
+<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Mon Jun 30 2025, 11:00 AM GMT+01:00<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
 </div>
 </body>
-</html><!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Thu Feb 27 2025, 6:06 AM GMT <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->
+</html><!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Mon Jun 30 2025, 11:00 AM GMT+01:00 <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->

--- a/static/reference/actionscript/3.0/flash/system/MessageChannel.html
+++ b/static/reference/actionscript/3.0/flash/system/MessageChannel.html
@@ -45,96 +45,183 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0	</td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+	</td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3.4
+
 	</td>
 </tr>
 </table>
 <p></p>
 <p></p>
+
  	The MessageChannel class provides a mechanism for a worker to communicate 
+
     with another worker. A message channel is a one-way 
+
     communication channel. The message channel's sending worker uses the 
+
     message channel to send objects to the receiving worker. A MessageChannel 
+
     object is the only way to send a message between workers that dispatches 
+
     an event indicating to the receiver that the message is available. Other 
+
     mechanisms for sharing data allow a value to be set but do not provide an 
+
     event to notify you of the changed data.
-        <p>Each MessageChannel object contains a queue of message objects sent 
+
+    
+    <p>Each MessageChannel object contains a queue of message objects sent 
+
     from the sending worker to the receiving worker. Each call to 
+
     <code>send()</code> adds an object to the queue. Each call to 
+
     <code>receive()</code> retrieves the oldest message object from the queue.</p>
-        <p>You do not create MessageChannel instances directly by calling the 
+
+    
+    <p>You do not create MessageChannel instances directly by calling the 
+
     <code>MessageChannel()</code> constructor. To create a MessageChannel 
+
     instance, call the <code>createMessageChannel()</code> method of the 
+
     Worker object that will send messages on the channel, passing the 
+
     receiving Worker object as an argument.</p>
-        <p>The typical workflow for sending messages with a MessageChannel object 
+
+    
+    <p>The typical workflow for sending messages with a MessageChannel object 
+
     is as follows:</p>
+
     <ol>
+
       <li><p>Call the sending worker's <code>createMessageChannel()</code> 
+
           method to create the message channel</p>
+
     <div class='listing'><pre>
+
     // In the sending worker swf
+
     var sendChannel:MessageChannel;
+
     sendChannel = Worker.current.createMessageChannel(receivingWorker);</pre></div>
+
       </li>
+
     
+
       <li><p>Pass the message channel to the other worker, either by calling 
+
           <code>Worker.setSharedProperty()</code> or by sending it through an existing message channel</p>
+
     <div class='listing'><pre>
+
     receivingWorker.setSharedProperty("incomingChannel", sendChannel);</pre></div>
+
       </li>
+
     
+
       <li><p>Code in the receiving worker registers a listener with the 
+
           MessageChannel object for the <code>channelMessage</code> event</p>
+
     <div class='listing'><pre>
+
     // In the receiving worker swf
+
     var incomingChannel:MessageChannel;
+
     incomingChannel = Worker.current.getSharedProperty("incomingChannel");
+
     incomingChannel.addEventListener(Event.CHANNEL_MESSAGE, handleIncomingMessage);</pre></div>
+
       </li>
+
     
+
       <li><p>Code in the sending worker sends a message by calling the 
+
           <code>send()</code> method</p>
+
     <div class='listing'><pre>
+
     // In the sending worker swf
+
     sendChannel.send("This is a message");</pre></div>
+
       </li>
+
     
+
       <li><p>The runtime calls the event handler in the receiving worker code, 
+
           indicating that a message has been sent</p>
+
     <div class='listing'><pre>
+
     // In the receiving worker swf
+
     // This method is called when the message channel gets a message
+
     private function handleIncomingMessage(event:Event):void
+
     {
+
         // Do something with the message, as shown in the next code listing
+
     }</pre></div>
+
       </li>
+
     
+
       <li><p>Code in the receiving worker calls the <code>receive()</code> 
+
           method to get the message. The object returned by the 
+
           <code>receive()</code> method has the same data type as the object 
+
           passed to the <code>send()</code> method.</p>
+
     <div class='listing'><pre>
+
     var message:String = incomingChannel.receive() as String;</pre></div>
+
       </li>
+
     </ol>
-        <p>In addition to the asynchronous workflow outlined above, you can use 
+
+    
+    <p>In addition to the asynchronous workflow outlined above, you can use 
+
     an alternative workflow with the <code>receive()</code> method to pause 
+
     the code in the receiving worker and wait until a message is sent. See 
+
     the <code>receive()</code> method description for more information.</p>
-	    <p>The MessageChannel class is one of the special object types that are shared 
+
+	
+    <p>The MessageChannel class is one of the special object types that are shared 
+
     between workers rather than copied between them. When you pass a message channel 
+
     from one worker to another worker either by calling the Worker object's 
+
     <code>setSharedProperty()</code> method or by using a MessageChannel object, 
+
     both workers have a reference to the same MessageChannel object in the runtime's memory.</p>
-        <p></p>
+
+    
+    <p></p>
 <p>
 <span class="classHeaderTableLabel">See also</span>
 </p>
@@ -171,7 +258,9 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <tr class="">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol"><a class="signatureLink" href="#messageAvailable">messageAvailable</a> : <a href="../../Boolean.html">Boolean</a>
 <div class="summaryTableDescription">[read-only]
+
         Indicates whether the MessageChannel has one or more messages from 
+
         the sending worker in its internal message queue.</div>
 </td><td class="summaryTableOwnerCol">MessageChannel</td>
 </tr>
@@ -185,7 +274,9 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <tr class="">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol"><a class="signatureLink" href="#state">state</a> : <a href="../../String.html">String</a>
 <div class="summaryTableDescription">[read-only]
+
         Indicates the current state of the MessageChannel object (open, 
+
 		closing, or closed).</div>
 </td><td class="summaryTableOwnerCol">MessageChannel</td>
 </tr>
@@ -222,7 +313,9 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="#close()">close</a>():<a href="../../specialTypes.html#void">void</a>
 </div>
 <div class="summaryTableDescription">
+
         Instructs the current MessageChannel to close once all messages have 
+
 		been received.</div>
 </td><td class="summaryTableOwnerCol">MessageChannel</td>
 </tr>
@@ -283,7 +376,9 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="#receive()">receive</a>(blockUntilReceived:<a href="../../Boolean.html">Boolean</a> = false):<a href="../../specialTypes.html#*">*</a>
 </div>
 <div class="summaryTableDescription">
+
         Retrieves a single message object from the queue of messages sent 
+
         through this message channel.</div>
 </td><td class="summaryTableOwnerCol">MessageChannel</td>
 </tr>
@@ -302,7 +397,9 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="#send()">send</a>(arg:<a href="../../specialTypes.html#*">*</a>, queueLimit:<a href="../../int.html">int</a> = -1):<a href="../../specialTypes.html#void">void</a>
 </div>
 <div class="summaryTableDescription">
+
 		Sends an object from the sending worker, adding it to the message 
+
         queue for the receiving worker.</div>
 </td><td class="summaryTableOwnerCol">MessageChannel</td>
 </tr>
@@ -388,8 +485,11 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="#event:channelMessage">channelMessage</a>
 </div>
 </td><td class="summaryTableDescription summaryTableCol">
+
     Dispatched each time the sending worker calls this MessageChannel 
+
     object's <code>send()</code> method, indicating that a new message object 
+
     is available in the MessageChannel instance's queue.</td><td class="summaryTableOwnerCol">MessageChannel</td>
 </tr>
 <tr class="">
@@ -398,7 +498,9 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="#event:channelState">channelState</a>
 </div>
 </td><td class="summaryTableDescription summaryTableCol">
+
     Dispatched when the value of the message channel's <code>state</code> 
+
     property changes.</td><td class="summaryTableOwnerCol">MessageChannel</td>
 </tr>
 <tr class="hideInheritedEvent">
@@ -429,19 +531,25 @@ showHideInherited();
 <code>messageAvailable:<a href="../../Boolean.html">Boolean</a></code>&nbsp;&nbsp;[read-only]<p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0		</td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+		</td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3.4
+
 </td>
 </tr>
 </table>
 <p></p><p>
+
         Indicates whether the MessageChannel has one or more messages from 
+
         the sending worker in its internal message queue.
-				</p><span class="label">Implementation</span>
+
+		
+		</p><span class="label">Implementation</span>
 <br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;public function get messageAvailable():<a href="../../Boolean.html">Boolean</a></code>
 <br>
@@ -456,20 +564,27 @@ showHideInherited();
 <code>state:<a href="../../String.html">String</a></code>&nbsp;&nbsp;[read-only]<p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0		</td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+		</td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3.4
+
 </td>
 </tr>
 </table>
 <p></p><p>
+
         Indicates the current state of the MessageChannel object (open, 
+
 		closing, or closed). The possible values for this property are 
+
 		defined as constants in the MessageChannelState class.
+
         
+
         </p><span class="label">Implementation</span>
 <br>
 <code>&nbsp;&nbsp;&nbsp;&nbsp;public function get state():<a href="../../String.html">String</a></code>
@@ -494,12 +609,14 @@ showHideInherited();
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0        </td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+        </td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3.4
+
 </td>
 </tr>
 </table>
@@ -632,34 +749,53 @@ showHideInherited();
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0		</td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+		</td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3.4
+
 </td>
 </tr>
 </table>
 <p></p><p>
+
         Instructs the current MessageChannel to close once all messages have 
+
 		been received.
-                </p><p>Once you call this method, you can no longer call the 
-		<code>send()</code> method to add messages to the queue. The 
-		<code>send()</code> call will fail and return <code>false</code>.</p>
+
         
+        </p><p>Once you call this method, you can no longer call the 
+
+		<code>send()</code> method to add messages to the queue. The 
+
+		<code>send()</code> call will fail and return <code>false</code>.</p>
+
+        
+
         <p>You can also only call the <code>receive()</code> method to 
+
 		receive messages that are already waiting in the queue. If the queue 
+
 		is empty, the <code>receive()</code> call will return <code>null</code>.</p>
-                <br>
+
+        
+        <br>
 <span class="label">Events</span>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20px"></td><td><code><b>channelState</b></code> &mdash; dispatched when the 
+
                <code>close()</code> method is called (which sets the 
+
                <code>state</code> property is to <code>MessageChannelState.CLOSING</code>). 
+
                Dispatched again when all the messages have been received and 
+
                the <code>state</code> property is set to 
+
                <code>MessageChannelState.CLOSED</code>.</td>
 </tr>
 </table>
@@ -675,54 +811,96 @@ showHideInherited();
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0		</td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+		</td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3.4
+
 </td>
 </tr>
 </table>
 <p></p><p>
+
         Retrieves a single message object from the queue of messages sent 
+
         through this message channel.
-                </p><p>Each time the sending worker's code calls the MessageChannel 
-		object's <code>send()</code> method, a single object is added to the 
-		message channel's internal message queue. These objects stack up in 
-		the queue until they are removed one at a time by the receiving 
-		worker calling the <code>receive()</code> method. The message objects 
-		are received in the order they are sent.</p>
-                <p>To check if the queue contains a message object to receive, use 
-		the <code>messageAvailable</code> property.</p>
+
         
+        </p><p>Each time the sending worker's code calls the MessageChannel 
+
+		object's <code>send()</code> method, a single object is added to the 
+
+		message channel's internal message queue. These objects stack up in 
+
+		the queue until they are removed one at a time by the receiving 
+
+		worker calling the <code>receive()</code> method. The message objects 
+
+		are received in the order they are sent.</p>
+
+        
+        <p>To check if the queue contains a message object to receive, use 
+
+		the <code>messageAvailable</code> property.</p>
+
+        
+
         <p>In the standard case, the object passed into <code>send()</code> 
+
 		is serialized in AMF3 format. When it is removed from the queue by 
+
 		the <code>receive()</code> call, it is deserialized into an 
+
 		ActionScript object (a copy of the original object) in the receiving 
+
 		worker and the worker receives a reference to that copy. Certain 
+
 		types of objects are shared between workers rather than copied. In 
+
 		that case the object that the receiving worker gets is a reference 
+
 		to the shared object itself rather than a new copy of the object. 
+
 		For more information about this case see the <code>send()</code> 
+
 		method description.</p>
-                <p>The method's behavior changes if the message queue is empty and 
+
+        
+        <p>The method's behavior changes if the message queue is empty and 
+
 		you pass <code>true</code> for the <code>blockUntilReceived</code> 
+
 		parameter. In that case the worker pauses its execution thread at 
+
 		the <code>receive()</code> call and does not execute more code. Once 
+
 		the sending worker calls <code>send()</code>, the 
+
 		<code>receive()</code> call completes by receiving the message. The 
+
 		worker then resumes code execution at the next line of code following 
+
 		the receive call.</p>
-                <span class="label">Parameters</span>
+
+        
+        <span class="label">Parameters</span>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20px"></td><td><code><span class="label">blockUntilReceived</span>:<a href="../../Boolean.html">Boolean</a></code> (default = <code>false</code>)<code></code> &mdash; indicates whether the worker's execution 
+
                thread should receive a message object and then continue 
+
                execution (<code>false</code>), or if it should pause at the 
+
                <code>receive()</code> call and wait for a message to be sent 
+
                if the queue is empty (<code>true</code>)
-                </td>
+
+        
+        </td>
 </tr>
 </table>
 <p></p>
@@ -730,12 +908,20 @@ showHideInherited();
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20"></td><td><code><a href="../../specialTypes.html#*">*</a></code> &mdash; a copy of the object passed into the <code>send()</code> 
+
                 method by the sending worker. If the object is one of the 
+
                 special types that are shared between workers, the return 
+
                 value is a reference to the shared object rather than to a 
+
                 copy of it. If no message is available on the queue, the 
+
                 method returns <code>null</code>.
-                        </td>
+
+        
+        
+        </td>
 </tr>
 </table>
 <br>
@@ -743,27 +929,39 @@ showHideInherited();
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20"></td><td><code><a href="../../Error.html">Error</a> </code> &mdash; if the channel is closed at the time the 
+
                 method is called or if the <code>blockUntilReceived</code> argument 
+
                 results in the execution being paused and the channel is then 
+
                 closed by another worker.
-                </td>
+
+        
+        </td>
 </tr>
 <tr>
 <td class="paramSpacer">&nbsp;</td>
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../ArgumentError.html">ArgumentError</a> </code> &mdash; if the calling code is not in the receiving worker
-                </td>
+
+        
+        </td>
 </tr>
 <tr>
 <td class="paramSpacer">&nbsp;</td>
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../errors/ScriptTimeoutError.html">ScriptTimeoutError</a> </code> &mdash; if the method is called from 
+
                 code in the primordial worker in Flash Player and the 
+
                 <code>blockUntilReceived</code> argument causes the worker to pause 
+
                 longer than the script timeout limit (15 seconds by default)
-                </td>
+
+        
+        </td>
 </tr>
 </table>
 <p>
@@ -786,12 +984,14 @@ showHideInherited();
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0        </td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+        </td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3.4
+
 </td>
 </tr>
 </table>
@@ -841,76 +1041,135 @@ showHideInherited();
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0		</td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+		</td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3.4
+
 	</td>
 </tr>
 </table>
 <p></p><p>
+
 		Sends an object from the sending worker, adding it to the message 
+
         queue for the receiving worker.
-                </p><p>The object passed to the <code>arg</code> parameter can be almost any 
+
+        
+        </p><p>The object passed to the <code>arg</code> parameter can be almost any 
+
         object. Other than the exceptions noted below, any object that is passed 
+
         to the <code>arg</code> parameter is not passed by reference. Any changes made to the 
+
         object in one worker after <code>send()</code> is called are 
+
         not carried over to the other worker. The object is copied by 
+
         serializing it to AMF3 format and deserializing it into a new object 
+
         in the receiving worker when <code>receive()</code> is called. 
+
         For this reason, any object that can't be serialized in AMF3 format, 
+
         including display objects, can't be passed to the <code>arg</code> parameter. 
+
         In order for a custom class to be passed properly, the class definition 
+
         must be registered using the <code>flash.net.registerClassAlias()</code> 
+
         function or <code>[RemoteClass]</code> metadata. With either technique 
+
         the same alias must be used for both worker's versions of the class.</p>
+
         
+
         <p>There are five types of objects that are an exception to the rule 
+
         that objects aren't shared between workers:</p>
-                <ul>
-          <li>Worker</li>
-          <li>MessageChannel</li>
-          <li>shareable ByteArray (a ByteArray object with its 
-              <code>shareable</code> property set to <code>true</code></li>
-          <li>Mutex</li>
-          <li>Condition</li>
-        </ul>
+
         
+        <ul>
+
+          <li>Worker</li>
+
+          <li>MessageChannel</li>
+
+          <li>shareable ByteArray (a ByteArray object with its 
+
+              <code>shareable</code> property set to <code>true</code>)</li>
+
+          <li>Mutex</li>
+
+          <li>Condition</li>
+
+        </ul>
+
+        
+
         <p>If you pass an instance of these objects to the <code>arg</code> 
+
         parameter, each worker has a reference to the same underlying object. 
+
         Changes made to an instance in one worker are immediately available 
+
         in other workers. In addition, if you pass the same instance of these 
+
         objects more than once using <code>send()</code>, the runtime doesn't 
+
         create a new copy of the object in the receiving worker. Instead, the 
+
         same reference is re-used, reducing system memory use.</p>
-                <p>By default, this method adds the object to the queue and immediately 
+
+        
+        <p>By default, this method adds the object to the queue and immediately 
+
         returns, continuing execution with the next line of code. If you want 
+
         to prevent the queue from growing beyond a certain size, you can use 
+
         the <code>queueLimit</code> parameter to specify the maximum number 
+
         of items to allow in the queue. If at the time you call 
+
         <code>send()</code> the number of items in the queue is greater than 
+
         the limit you specify, the worker pauses the execution thread at the 
+
         <code>send()</code> call. Once the receiving worker calls 
+
         <code>receive()</code> enough times that the queue size is less than 
+
         the specified queue limit, the send() call completes. The worker then 
+
         continues execution at the next line of code.</p>
-                <span class="label">Parameters</span>
+
+        
+        <span class="label">Parameters</span>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20px"></td><td><code><span class="label">arg</span>:<a href="../../specialTypes.html#*">*</a></code> &mdash; the object to add to the message queue
-                </td>
+
+        
+        </td>
 </tr>
 <tr>
 <td class="paramSpacer">&nbsp;</td>
 </tr>
 <tr>
 <td width="20px"></td><td><code><span class="label">queueLimit</span>:<a href="../../int.html">int</a></code> (default = <code>-1</code>)<code></code> &mdash; the maximum number of message objects that the 
+
                message queue can contain. If the queue contains more objects 
+
                than the limit, the sending worker pauses execution until 
+
                messages are received and the queue size drops below the limit.
+
         
+
         </td>
 </tr>
 </table>
@@ -919,6 +1178,7 @@ showHideInherited();
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20px"></td><td><code><b>channelMessage</b></code> &mdash; dispatched to notify the 
+
                receiving worker that a message object is available in the queue</td>
 </tr>
 </table>
@@ -927,27 +1187,39 @@ showHideInherited();
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20"></td><td><code><a href="../../Error.html">Error</a> </code> &mdash; if the channel is closed at the time the 
+
                 method is called or if the <code>queueLimit</code> argument 
+
                 results in the execution being paused and the channel is then 
+
                 closed by another worker.
-                </td>
+
+        
+        </td>
 </tr>
 <tr>
 <td class="paramSpacer">&nbsp;</td>
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../../ArgumentError.html">ArgumentError</a> </code> &mdash; if the calling code is not in the sending worker
-                </td>
+
+        
+        </td>
 </tr>
 <tr>
 <td class="paramSpacer">&nbsp;</td>
 </tr>
 <tr>
 <td width="20"></td><td><code><a href="../errors/ScriptTimeoutError.html">ScriptTimeoutError</a> </code> &mdash; if the method is called from 
+
                 code in the primordial worker in Flash Player and the 
+
                 <code>queueLimit</code> argument causes the worker to pause 
+
                 longer than the script timeout limit (15 seconds by default)
+
         
+
         </td>
 </tr>
 </table>
@@ -977,12 +1249,14 @@ showHideInherited();
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0        </td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+        </td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3.4
+
 </td>
 </tr>
 </table>
@@ -1023,20 +1297,27 @@ showHideInherited();
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0    </td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+    </td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3.4
+
 </td>
 </tr>
 </table>
 <p></p><p>
+
     Dispatched each time the sending worker calls this MessageChannel 
+
     object's <code>send()</code> method, indicating that a new message object 
+
     is available in the MessageChannel instance's queue.
+
     
+
     </p><p>
 	The <code>Event.CHANNEL_MESSAGE</code> constant defines the value of the <code>type</code> property of a <code>channelMessage</code> event object.
  	 	</p><p>This event has the following properties:</p>
@@ -1062,19 +1343,25 @@ showHideInherited();
 <p></p>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
-<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0    </td>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0
+    </td>
 </tr>
 </table>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;3.4
+
 </td>
 </tr>
 </table>
 <p></p><p>
+
     Dispatched when the value of the message channel's <code>state</code> 
+
     property changes.
+
     
+
     </p><p>
 	The <code>Event.CHANNEL_STATE</code> constant defines the value of the <code>type</code> property of a <code>channelState</code> event object.
  	 	</p><p>This event has the following properties:</p>
@@ -1093,11 +1380,10 @@ showHideInherited();
 <p></p>
 <div class="feedbackLink">
 <center>
-<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Wed Sep 28 2022, 6:12 PM GMT+01:00) : flash.system.MessageChannel">Submit Feedback</a>
+<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Mon Jun 30 2025, 11:00 AM GMT+01:00) : flash.system.MessageChannel">Submit Feedback</a>
 </center>
 </div>
-<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Wed Sep 28 2022, 6:12 PM GMT+01:00<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
+<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Mon Jun 30 2025, 11:00 AM GMT+01:00<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
 </div>
 </body>
-</html>
-<!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Wed Sep 28 2022, 6:12 PM GMT+01:00 <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->
+</html><!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Mon Jun 30 2025, 11:00 AM GMT+01:00 <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->

--- a/static/reference/actionscript/3.0/flash/utils/ByteArray.html
+++ b/static/reference/actionscript/3.0/flash/utils/ByteArray.html
@@ -1029,7 +1029,7 @@ showHideInherited();
 
 	 then passing it as an argument to MessageChannel.send to another worker
 
-	 or via Worker.setStartArgument()
+	 or via Worker.setSharedProperty()
 
 	 will always create a complete byte array copy,
 
@@ -1040,7 +1040,7 @@ showHideInherited();
 
 	 then passing it as an argument to MessageChannel.send to another worker
 
-	 or via Worker.setStartArgument()
+	 or via Worker.setSharedProperty()
 
 	 will result in a byte array object in the remote worker
 
@@ -1137,7 +1137,7 @@ showHideInherited();
 <td class="paramSpacer">&nbsp;</td>
 </tr>
 <tr>
-<td width="20px"></td><td><code><span class="label">expectedValue</span>:<a href="../../int.html">int</a></code> &mdash; int containing the expected value of the integter to be
+<td width="20px"></td><td><code><span class="label">expectedValue</span>:<a href="../../int.html">int</a></code> &mdash; int containing the expected value of the integer to be
 
             replaced by the newValue parameter.
 
@@ -3441,11 +3441,10 @@ package {
 <p></p>
 <div class="feedbackLink">
 <center>
-<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Mon Feb 12 2024, 3:03 PM GMT) : flash.utils.ByteArray">Submit Feedback</a>
+<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Mon Jun 30 2025, 11:00 AM GMT+01:00) : flash.utils.ByteArray">Submit Feedback</a>
 </center>
 </div>
-<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Mon Feb 12 2024, 3:03 PM GMT<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
+<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Mon Jun 30 2025, 11:00 AM GMT+01:00<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
 </div>
 </body>
-</html>
-<!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Mon Feb 12 2024, 3:03 PM GMT <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->
+</html><!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Mon Jun 30 2025, 11:00 AM GMT+01:00 <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->

--- a/static/reference/actionscript/3.0/package-list.html
+++ b/static/reference/actionscript/3.0/package-list.html
@@ -51,6 +51,16 @@
 </td>
 </tr>
 <tr>
+<td><a onclick="javascript:loadClassListFrame('avm2/intrinsics/iteration/class-list.html');" href="avm2/intrinsics/iteration/package-detail.html">avm2.intrinsics.iteration</a>
+<br>
+</td>
+</tr>
+<tr>
+<td><a onclick="javascript:loadClassListFrame('avm2/intrinsics/memory/class-list.html');" href="avm2/intrinsics/memory/package-detail.html">avm2.intrinsics.memory</a>
+<br>
+</td>
+</tr>
+<tr>
 <td><a onclick="javascript:loadClassListFrame('flash/accessibility/class-list.html');" href="flash/accessibility/package-detail.html">flash.accessibility</a>
 <br>
 </td>
@@ -258,4 +268,4 @@
 </tr>
 </table>
 </body>
-</html><!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Thu Feb 27 2025, 6:06 AM GMT <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->
+</html><!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Mon Jun 30 2025, 11:00 AM GMT+01:00 <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->

--- a/static/reference/actionscript/3.0/package-summary.html
+++ b/static/reference/actionscript/3.0/package-summary.html
@@ -67,6 +67,12 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Al
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a onclick="javascript:loadClassListFrame('air/utils/class-list.html');" href="air/utils/package-detail.html">air.utils</a></td><td class="summaryTableLastCol">&nbsp;</td>
 </tr>
 <tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a onclick="javascript:loadClassListFrame('avm2/intrinsics/iteration/class-list.html');" href="avm2/intrinsics/iteration/package-detail.html">avm2.intrinsics.iteration</a></td><td class="summaryTableLastCol">The amv2.intrinsics.iteration package includes the low-level/intrinsic iteration APIs that are part of the ASC2 compiler.</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a onclick="javascript:loadClassListFrame('avm2/intrinsics/memory/class-list.html');" href="avm2/intrinsics/memory/package-detail.html">avm2.intrinsics.memory</a></td><td class="summaryTableLastCol">The amv2.intrinsics.memory package includes the low-level/intrinsic memory access APIs that are part of the ASC2 compiler.</td>
+</tr>
+<tr class="prow0">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a onclick="javascript:loadClassListFrame('flash/accessibility/class-list.html');" href="flash/accessibility/package-detail.html">flash.accessibility</a></td><td class="summaryTableLastCol">The flash.accessibility package contains classes for supporting accessibility in Flash content and applications.</td>
 </tr>
 <tr class="prow1">
@@ -167,7 +173,7 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Al
 </tr>
 </table>
 <p></p>
-<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Thu Feb 27 2025, 6:06 AM GMT<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
+<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Mon Jun 30 2025, 11:00 AM GMT+01:00<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
 </div>
 </body>
-</html><!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Thu Feb 27 2025, 6:06 AM GMT <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->
+</html><!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Mon Jun 30 2025, 11:00 AM GMT+01:00 <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->

--- a/static/reference/actionscript/3.0/runtimeErrors.html
+++ b/static/reference/actionscript/3.0/runtimeErrors.html
@@ -48,1023 +48,767 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Ru
 <th>&nbsp;</th><th>Code</th><th width="35%">Message</th><th>Description</th>
 </tr>
 <tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1000"></a><b>1000</b></td><td valign="top" class="summaryTableCol">Ambiguous reference to _.
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1000"></a><b>1000</b></td><td valign="top" class="summaryTableCol">The system is out of memory.
+</td><td class="summaryTableLastCol">
+        Flash Player needs more memory to compile your code than your system has available.
+        Close some of the applications or processes running on your system.
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1001"></a><b>1001</b></td><td valign="top" class="summaryTableCol">The method _ is not implemented.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1002"></a><b>1002</b></td><td valign="top" class="summaryTableCol">Number.toPrecision has a range of 1 to 21. Number.toFixed and Number.toExponential have a range of 0 to 20. Specified value is not within expected range.
+</td><td class="summaryTableLastCol">
+        You specified a value that is not within the expected range of the <code>precision</code> argument. Number.toPrecision has a range of 1 to 21. Number.toFixed and Number.toExponential have a range of 0 to 20.
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1003"></a><b>1003</b></td><td valign="top" class="summaryTableCol">The radix argument must be between 2 and 36; got _.
+     </td><td class="summaryTableLastCol">
+        You passed a value less than 2 or greater than 36 for the <code>radix</code> argument of a method or property.
+        Pass a value between 2 and 36 as a <code>radix</code> argument.
+    </td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1004"></a><b>1004</b></td><td valign="top" class="summaryTableCol">Method _ was invoked on an incompatible object.
+</td><td class="summaryTableLastCol">
+        You tried to call a method that is not available to the specified object. This error occurs when
+        you have copied a prototype function from one object to another, and then invoked it, but the
+        target object is not the same type as the original object. Ensure that the target object and
+        original object are the same type. See the ECMAScript Language Specification, 3rd Edition, Chapter 15 for more details.
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1005"></a><b>1005</b></td><td valign="top" class="summaryTableCol">Array index is not a positive integer (_).
+</td><td class="summaryTableLastCol">
+        You tried to access a member of an array using an index value that is not a positive integer. Pass only positive integers as index values for arrays.
+    </td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1006"></a><b>1006</b></td><td valign="top" class="summaryTableCol">_ is not a function.
+</td><td class="summaryTableLastCol">
+        This error occurs when you attempt to call a function that does not exist.
+        Make sure you are calling the correct function, and that the API has
+        not changed from ActionScript 2.0. Also, make sure you are using the correct
+        object. For example, you will see this error when you use the following code
+        (because the last line mistakenly calls the variable <code>big</code> instead
+        of <code>blg</code>):
+
+        <pre><code>var blg:String = "foo";
+var big:Sprite = new Sprite();
+var error:int = big.length(); </code></pre>
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1007"></a><b>1007</b></td><td valign="top" class="summaryTableCol">Instantiation attempted on a non-constructor.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1008"></a><b>1008</b></td><td valign="top" class="summaryTableCol">_ is ambiguous; Found more than one matching binding.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1009"></a><b>1009</b></td><td valign="top" class="summaryTableCol">Cannot access a property or method of a null object reference.
+</td><td class="summaryTableLastCol">
+    An object that evaluates to <code>null</code> can have no properties. This error can occur in some unexpected
+    (though valid) situations. For example, consider the following code, which creates a Sprite
+    object. Because this Sprite object is never added to the display list (through the
+    <code>addChild()</code> method of a DisplayObjectContainer object), its <code>stage</code>
+    property is set to <code>null</code>. Thus, the example generates this error because Sprite object's <code>stage</code> property
+    cannot have any properties:
+
+    <pre><code>import flash.display.Sprite;
+var sprite1:Sprite = new Sprite();
+var q:String = sprite1.stage.quality;</code></pre>
+    </td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1010"></a><b>1010</b></td><td valign="top" class="summaryTableCol">A term is undefined and has no properties.
+</td><td class="summaryTableLastCol">
+        This error can occur if you try to access a property of an object that does not exist. For example:
+        <pre><code>var obj:Object = new Object();
+obj.a = "foo";
+trace(obj.b.prop);</code></pre>
+
+        <p>You can also see this error because of a misspelling, for example in the following, where
+        <code>mc</code> represents a MovieClip object in the display list, and the <code>stage</code>
+        property is misspelled with a capital S (it should be <code>stage</code>):</p>
+
+        <pre><code>trace(mc.Stage.quality);</code></pre>
 
 
-	</td><td class="summaryTableLastCol">
-	A reference might be to more than one item. For example, the following uses the namespaces <code>rss</code> and <code>xml</code>, each of which defines a 
-	different value for the <code>hello()</code> function. The 		
-	<code>trace(hello())</code> statement returns this error because it cannot determine which namespace to use.
-	
-<pre><code>private namespace rss;
-private namespace xml;
-    
-public function ErrorExamples() {
-  	use namespace rss;
-   	use namespace xml;
-	trace(hello());
-}
-    
-rss function hello():String {
-      	return "hola";
-    }
-    
-    xml function hello():String {
-        return "foo";
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1011"></a><b>1011</b></td><td valign="top" class="summaryTableCol">Method _ contained illegal opcode _ at offset _.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1012"></a><b>1012</b></td><td valign="top" class="summaryTableCol">The last instruction exceeded code size.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1013"></a><b>1013</b></td><td valign="top" class="summaryTableCol">Cannot call OP_findproperty when scopeDepth is 0.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1014"></a><b>1014</b></td><td valign="top" class="summaryTableCol">Class _ could not be found.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1015"></a><b>1015</b></td><td valign="top" class="summaryTableCol">Method _ cannot set default xml namespace
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1016"></a><b>1016</b></td><td valign="top" class="summaryTableCol">Descendants operator (..) not supported on type _.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1017"></a><b>1017</b></td><td valign="top" class="summaryTableCol">Scope stack overflow occurred.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1018"></a><b>1018</b></td><td valign="top" class="summaryTableCol">Scope stack underflow occurred.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1019"></a><b>1019</b></td><td valign="top" class="summaryTableCol">Getscopeobject _ is out of bounds.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1020"></a><b>1020</b></td><td valign="top" class="summaryTableCol">Code cannot fall off the end of a method.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1021"></a><b>1021</b></td><td valign="top" class="summaryTableCol">At least one branch target was not on a valid instruction in the method.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1022"></a><b>1022</b></td><td valign="top" class="summaryTableCol">Type void may only be used as a function return type.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1023"></a><b>1023</b></td><td valign="top" class="summaryTableCol">Stack overflow occurred.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1024"></a><b>1024</b></td><td valign="top" class="summaryTableCol">Stack underflow occurred.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1025"></a><b>1025</b></td><td valign="top" class="summaryTableCol">An invalid register _ was accessed.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1026"></a><b>1026</b></td><td valign="top" class="summaryTableCol">Slot _ exceeds slotCount=_ of _.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1027"></a><b>1027</b></td><td valign="top" class="summaryTableCol">Method_info _ exceeds method_count=_.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1028"></a><b>1028</b></td><td valign="top" class="summaryTableCol">Disp_id _ exceeds max_disp_id=_ of _.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1029"></a><b>1029</b></td><td valign="top" class="summaryTableCol">Disp_id _ is undefined on _.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1030"></a><b>1030</b></td><td valign="top" class="summaryTableCol">Stack depth is unbalanced. _ != _.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1031"></a><b>1031</b></td><td valign="top" class="summaryTableCol">Scope depth is unbalanced. _ != _.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1032"></a><b>1032</b></td><td valign="top" class="summaryTableCol">Cpool index _ is out of range _.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1033"></a><b>1033</b></td><td valign="top" class="summaryTableCol">Cpool entry _ is wrong type.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1034"></a><b>1034</b></td><td valign="top" class="summaryTableCol">Type Coercion failed: cannot convert _ to _.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1035"></a><b>1035</b></td><td valign="top" class="summaryTableCol">Illegal super expression found in method _.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1037"></a><b>1037</b></td><td valign="top" class="summaryTableCol">Cannot assign to a method _ on _.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1038"></a><b>1038</b></td><td valign="top" class="summaryTableCol">_ is already defined.
+</td><td class="summaryTableLastCol">
+        You cannot declare a variable or function with the same identifier name more than once
+        within the same scope.
+        In ActionScript 3.0, different code blocks (such as those used in two <code>for</code> loops
+        in the same <code>function</code> definition) are considered to be in the same scope.
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1039"></a><b>1039</b></td><td valign="top" class="summaryTableCol">Cannot verify method until it is referenced.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1040"></a><b>1040</b></td><td valign="top" class="summaryTableCol">The right-hand side of instanceof must be a class or function.
+</td><td class="summaryTableLastCol">
+        The expression on the right side of the <code>instanceof</code> operator must be a class or function.
+    </td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1041"></a><b>1041</b></td><td valign="top" class="summaryTableCol">The right-hand side of operator must be a class.
+</td><td class="summaryTableLastCol">
+        The expression on the right side of the <code>is</code> operator must be a class.
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1042"></a><b>1042</b></td><td valign="top" class="summaryTableCol">Not an ABC file.  major_version=_ minor_version=_.
+</td><td class="summaryTableLastCol">
+You are attempting to use an  invalid file with the player: the tool that generates the SWF may be out of date or the SWF itself may be corrupt.
+    </td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1043"></a><b>1043</b></td><td valign="top" class="summaryTableCol">Invalid code_length=_.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1044"></a><b>1044</b></td><td valign="top" class="summaryTableCol">MethodInfo-_ unsupported flags=_.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1045"></a><b>1045</b></td><td valign="top" class="summaryTableCol">Unsupported traits kind=_.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1046"></a><b>1046</b></td><td valign="top" class="summaryTableCol">MethodInfo-_ referenced before definition.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1047"></a><b>1047</b></td><td valign="top" class="summaryTableCol">No entry point was found.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1049"></a><b>1049</b></td><td valign="top" class="summaryTableCol">Prototype objects must be vanilla Objects.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1050"></a><b>1050</b></td><td valign="top" class="summaryTableCol">Cannot convert _ to primitive.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1051"></a><b>1051</b></td><td valign="top" class="summaryTableCol">Illegal early binding access to _.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1052"></a><b>1052</b></td><td valign="top" class="summaryTableCol">Invalid URI passed to _ function.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1053"></a><b>1053</b></td><td valign="top" class="summaryTableCol">Illegal override of _ in _.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1054"></a><b>1054</b></td><td valign="top" class="summaryTableCol">Illegal range or target offsets in exception handler.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1056"></a><b>1056</b></td><td valign="top" class="summaryTableCol">Cannot create property _ on _.
+</td><td class="summaryTableLastCol">
+    You are trying to assign a value to a nonexistent property on an instance of a non-dynamic
+    class. This is only possible for instances of dynamic classes</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1057"></a><b>1057</b></td><td valign="top" class="summaryTableCol">_ can only contain methods.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1058"></a><b>1058</b></td><td valign="top" class="summaryTableCol">Illegal operand type: _ must be _.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1059"></a><b>1059</b></td><td valign="top" class="summaryTableCol">ClassInfo-_ is referenced before definition.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1060"></a><b>1060</b></td><td valign="top" class="summaryTableCol">ClassInfo _ exceeds class_count=_.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1061"></a><b>1061</b></td><td valign="top" class="summaryTableCol">The value _ cannot be converted to _ without losing precision.
+</td><td class="summaryTableLastCol">
+
+        This error appears if you attempt to assign a decimal number to a property that has data type
+        int.
+
+        <p>This error also appears for out-of-range assignments, such as the following:</p>
+
+        <pre><code>var m0:int = 2147483648; // int.MAX_VALUE == 2147483647</code></pre>
+        <p>You can also see this error when using the bitwise left shift operator (&lt&lt).
+        For example, consider the following code:</p>
+
+        <pre><code>var m0:uint = 0xFF;
+var m1:uint = m0&lt&lt24;</code></pre>
+
+        <p>The result of left shift operator (&lt&lt) is interpreted as a 32-bit two's complement number
+        with sign. In the example, the result is a negative value, which causes the error when assigned
+        to the uint typed property. A workaround is the following:</p>
+
+        <pre><code>var m0:uint = 0xFF;
+var m1:uint = uint(m0&lt;&lt;24);</code></pre>
+
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1063"></a><b>1063</b></td><td valign="top" class="summaryTableCol">Argument count mismatch on _. Expected _, got _.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1064"></a><b>1064</b></td><td valign="top" class="summaryTableCol">Cannot call method _ as constructor.
+  </td><td class="summaryTableLastCol">
+    Extracted methods are permanently bound to the object they are extracted from.
+    Therefore, they can not later be called as a constructor. For example, the following
+    creates function <code>f()</code> in Class A:
+    <pre><code>class A {
+       function f() {}
     }</code></pre>
- 
+    In the following code, extracting the function causes no error. However, creating
+    a new instance of the function causes an error.
+    <pre><code>var a = new A()
+    var m = a.f // extract f, don't call it
+    m() // same as a.f()
+    new m() // causes this error</code></pre>
 
-	<p>Correct an ambiguous reference by making the reference specific. The following example uses the form <i>namespace</i>::<i>function</i> to specify 
-	which namespace to use:</p>
-
-
-<pre><code>public function ErrorExamples() {
-    
-    trace(rss::hello());
-    trace(xml::hello());
-}</code></pre>
-        
-	
-	</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1003"></a><b>1003</b></td><td valign="top" class="summaryTableCol">Access specifiers are not allowed with namespace attributes.
-		</td><td class="summaryTableLastCol">You can not use both an access specifier (such as private or public) and a namespace attribute on a definition.</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1004"></a><b>1004</b></td><td valign="top" class="summaryTableCol">Namespace was not found or is not a compile-time constant.
-	
-</td><td class="summaryTableLastCol">
-		The namespace is either unknown or is an expression that could have different values at run time.
-		Check that you are spelling the namespace correctly and that its definition is imported correctly.</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1006"></a><b>1006</b></td><td valign="top" class="summaryTableCol">A super expression can be used only inside class instance methods.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1007"></a><b>1007</b></td><td valign="top" class="summaryTableCol">A super statement can be used only inside class instance constructors.
-</td><td class="summaryTableLastCol">
-		You cannot use the <code>super</code> statement within static members. You can 
-		use the <code>super</code> statement only within class instances.
-	
-	</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1008"></a><b>1008</b></td><td valign="top" class="summaryTableCol">Attribute is invalid.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1010"></a><b>1010</b></td><td valign="top" class="summaryTableCol">The override attribute may be used only on class property definitions.
-</td><td class="summaryTableLastCol">
-		You cannot use the <code>override</code> keyword within a function block.
-	</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1011"></a><b>1011</b></td><td valign="top" class="summaryTableCol">The virtual attribute may be used only on class property definitions.
-</td><td class="summaryTableLastCol">
-		You cannot use the <code>virtual</code> attribute when you declare a property that does not belong to a class 
-		(for example, when you declare a variable within a function block).
-	</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1012"></a><b>1012</b></td><td valign="top" class="summaryTableCol">The static attribute may be used only on definitions inside a class.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1013"></a><b>1013</b></td><td valign="top" class="summaryTableCol">The private attribute may be used only on class property definitions.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1014"></a><b>1014</b></td><td valign="top" class="summaryTableCol">The intrinsic attribute is no longer supported.
-</td><td class="summaryTableLastCol">
-		ActionScript 3.0 does not support the intrinsic keyword.
-	</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1016"></a><b>1016</b></td><td valign="top" class="summaryTableCol">Base class is final.
-</td><td class="summaryTableLastCol">
-		The superclass cannot be extended because it is marked 
-		as <code>final</code>.
-	</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1017"></a><b>1017</b></td><td valign="top" class="summaryTableCol">The definition of base class _ was not found.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1018"></a><b>1018</b></td><td valign="top" class="summaryTableCol">Duplicate class definition: _.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1020"></a><b>1020</b></td><td valign="top" class="summaryTableCol">Method marked override must override another method.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1021"></a><b>1021</b></td><td valign="top" class="summaryTableCol">Duplicate function definition.
-</td><td class="summaryTableLastCol">
-		You cannot declare more than one function with the same identifier name within the same scope.
-	</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1022"></a><b>1022</b></td><td valign="top" class="summaryTableCol">Cannot override a final accessor.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1023"></a><b>1023</b></td><td valign="top" class="summaryTableCol">Incompatible override.
-</td><td class="summaryTableLastCol"> A function marked override must exactly match the parameter and return type declaration of the function it is overriding. 
-It must have the same number of parameters, each of the same type, and declare the same return type.  If any of the parameters are optional, that
-must match as well.  Both functions must use the same access specifier (public, private, and so on) or namespace attribute as well.</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1024"></a><b>1024</b></td><td valign="top" class="summaryTableCol">Overriding a function that is not marked for override.
-</td><td class="summaryTableLastCol">
-		
-		If a method in a class overrides a method in a base class, you must explicitly declare it by using the <code>override</code> attribute, as this example shows:
-
-		<pre>public override function foo():void{};</pre>
-	
-	</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1025"></a><b>1025</b></td><td valign="top" class="summaryTableCol">Cannot redefine a final method.
-</td><td class="summaryTableLastCol">
-		The method cannot be extended because it is marked
-		as <code>final</code> in the base class.
-	</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1026"></a><b>1026</b></td><td valign="top" class="summaryTableCol">Constructor functions must be instance methods.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1027"></a><b>1027</b></td><td valign="top" class="summaryTableCol">Functions cannot be both static and override.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1028"></a><b>1028</b></td><td valign="top" class="summaryTableCol">Functions cannot be both static and virtual.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1029"></a><b>1029</b></td><td valign="top" class="summaryTableCol">Functions cannot be both final and virtual.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1030"></a><b>1030</b></td><td valign="top" class="summaryTableCol">Must specify name of variable arguments array.
-</td><td class="summaryTableLastCol">
-	
-		The ...(rest) parameter definition specifies that all values supplied after ...(rest) 
-		are collected into any array.  
-		You must specify a name for the array, as in the expression 
-		<code>function foo(x,...(rest))</code>.
-
-	
-	</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1033"></a><b>1033</b></td><td valign="top" class="summaryTableCol">Virtual variables are not supported.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1034"></a><b>1034</b></td><td valign="top" class="summaryTableCol">Variables cannot be native.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1035"></a><b>1035</b></td><td valign="top" class="summaryTableCol">Variables cannot be both final and virtual.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1037"></a><b>1037</b></td><td valign="top" class="summaryTableCol">Packages cannot be nested.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1038"></a><b>1038</b></td><td valign="top" class="summaryTableCol">Target of break statement was not found.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1039"></a><b>1039</b></td><td valign="top" class="summaryTableCol">Target of continue statement was not found.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1040"></a><b>1040</b></td><td valign="top" class="summaryTableCol">Duplicate label definition.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1041"></a><b>1041</b></td><td valign="top" class="summaryTableCol">Attributes are not callable.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1042"></a><b>1042</b></td><td valign="top" class="summaryTableCol">The this keyword can not be used in static methods. It can only be used in instance methods, function closures, and global code.
-</td><td class="summaryTableLastCol">
-	
-		You cannot use the <code>this</code> keyword within a static member, because 
-		<code>this</code> would have no context.
-	
-	</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1043"></a><b>1043</b></td><td valign="top" class="summaryTableCol">Undefined namespace.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1044"></a><b>1044</b></td><td valign="top" class="summaryTableCol">Interface method _ in namespace _ not implemented by class _.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1045"></a><b>1045</b></td><td valign="top" class="summaryTableCol">Interface _ was not found.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1046"></a><b>1046</b></td><td valign="top" class="summaryTableCol">Type was not found or was not a compile-time constant: _.
-</td><td class="summaryTableLastCol">
-		
-		The class used as a type declaration is either unknown or is an expression that could have different values at run time.
-		Check that you are importing the correct class and that its package location
-		has not changed. Also, check that the package that contains the code (not the
-		imported class) is defined correctly (for example, make sure to use proper
-		ActionScript 3.0 package syntax, and not ActionScript 2.0 syntax).
-
-		<p>The error can also occur if the class being referenced is not defined in a namespace that is in use or is not defined as public:</p>
-
-		<pre><code>public class Foo{}</code></pre>
-
-        <p>If you are using Flex&#153 Builder&#153 2 and the class is in a library,
-		make sure to set the class path for the project.</p>
-
-
-	
-	</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1047"></a><b>1047</b></td><td valign="top" class="summaryTableCol">Parameter initializer unknown or is not a compile-time constant.
-	
-	</td><td class="summaryTableLastCol">
-	The value used as the default value for the parameter is either undefined or could have different values at run time. Check that the initializer is spelled 
-	correctly, and that the initializer value isn't an expression that could result in different possible values at run time.
-	</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1048"></a><b>1048</b></td><td valign="top" class="summaryTableCol">Method cannot be used as a constructor.
-	
-	</td><td class="summaryTableLastCol">
-	It is not possible to create an instance of a method of a class.  Only global functions can be used in <code>new</code> expressions.
-	
-<pre>class D { function xx() { return 22; } }
-var d:D = new D();
-var x = new d.xx(); // error, method cannot be used as constructor
-function yy() { this.a = 22; }
-var z = new yy(); // no error, global functions can be used as constructors.</pre>
-
-	</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1049"></a><b>1049</b></td><td valign="top" class="summaryTableCol">Illegal assignment to a variable specified as constant.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1050"></a><b>1050</b></td><td valign="top" class="summaryTableCol">Cannot assign to a non-reference value.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1051"></a><b>1051</b></td><td valign="top" class="summaryTableCol">Return value must be undefined.
-</td><td class="summaryTableLastCol">
-		You are attempting to use the <code>return</code> statement within a method that
-		has a declared return type <code>void</code>.
-	</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1052"></a><b>1052</b></td><td valign="top" class="summaryTableCol">Constant initializer unknown or is not a compile-time constant.
-
-	</td><td class="summaryTableLastCol">
-	The value used to initialize the constant is either undefined or could have different values at run time. Check that the initializer is spelled 
-	correctly, and that the initializer value isn't an expression that could result in different possible values at run time.
-	</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1053"></a><b>1053</b></td><td valign="top" class="summaryTableCol">Accessor types must match.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1054"></a><b>1054</b></td><td valign="top" class="summaryTableCol">Return type of a setter definition must be unspecified or void.
-</td><td class="summaryTableLastCol">
-		You cannot specify a return value for a setter function. For example, the following is invalid:
-
-		<pre>public function set gamma(g:Number):Number;</pre>
-
-		<p>The following <em>is</em> valid:</p>
-
-		<pre>public function set gamma(g:Number):void;</pre>
-	</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1058"></a><b>1058</b></td><td valign="top" class="summaryTableCol">Property is write-only.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1059"></a><b>1059</b></td><td valign="top" class="summaryTableCol">Property is read-only.
-
-	</td><td class="summaryTableLastCol">
-	This property is defined through a getter function, which allows you to retrieve that property's value. There is no setter function defined 
-	for this property, however, so it is read-only.
-	<p>In the following example, line 3 generates an error because there is no setter function defined for <code>xx</code>:</p>
-	
-<pre>class D { function get xx() { return 22; } }
-var d:D = new D();
-d.xx = 44; // error, property is read-only</pre>
-	</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1061"></a><b>1061</b></td><td valign="top" class="summaryTableCol">Call to a possibly undefined method _ through a reference with static type _.
-
-	</td><td class="summaryTableLastCol">
-	You are calling a method that is not defined.
-	</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1063"></a><b>1063</b></td><td valign="top" class="summaryTableCol">Unable to open file: _.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1064"></a><b>1064</b></td><td valign="top" class="summaryTableCol">Invalid metadata.
-	</td><td class="summaryTableLastCol">
-	This metadata is unrecognized.
-	</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1065"></a><b>1065</b></td><td valign="top" class="summaryTableCol">Metadata attributes cannot have more than one element.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1067"></a><b>1067</b></td><td valign="top" class="summaryTableCol">Implicit coercion of a value of type _ to an unrelated type _.
-</td><td class="summaryTableLastCol">
-		You are attempting to cast an object to a type to which it cannot be converted. This can happen
-		if the class you are casting to is not in the inheritance chain of the object being cast.
-		This error appears only when the compiler is running in strict mode.
-	</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1068"></a><b>1068</b></td><td valign="top" class="summaryTableCol">Unable to open included file: _.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1069"></a><b>1069</b></td><td valign="top" class="summaryTableCol">Syntax error: definition or directive expected.
-
-</td><td class="summaryTableLastCol">
-		Check the syntax in the line.
-	</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1071"></a><b>1071</b></td><td valign="top" class="summaryTableCol">Syntax error: expected a definition keyword (such as function) after attribute _, not _.
-</td><td class="summaryTableLastCol">
-	
-		This error will occur if the author forgets to use the "var" or "function" keyword in a declaration.
-<pre><code>public int z;// should be 'public var z:int;'</code></pre>
-
-		This error might also occur when the compiler encounters an unexpected character. For example,
-		the following use of the <code>trace()</code> function is invalid, because of the missing
-		parentheses (the correct syntax is <code>trace("hello")</code>):
-
-<pre>
-trace "hello"
-</pre>
-	
-	</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1072"></a><b>1072</b></td><td valign="top" class="summaryTableCol">Syntax error: expecting xml before namespace.
-</td><td class="summaryTableLastCol">
-	
-		The correct statement syntax is <code>default xml namespace = </code> <em>ns</em>. Either the keyword <code>xml</code> (note the lowercase) 
-		is missing or an incorrect keyword was used. For more
-		information, see the <a href="statements.html#default_xml_namespace">default xml namespace</a>
-		directive.
-	
-	</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1073"></a><b>1073</b></td><td valign="top" class="summaryTableCol">Syntax error: expecting a catch or a finally clause.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1075"></a><b>1075</b></td><td valign="top" class="summaryTableCol">Syntax error: the 'each' keyword is not allowed without an 'in' operator.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1076"></a><b>1076</b></td><td valign="top" class="summaryTableCol">Syntax error: expecting left parenthesis before the identifier.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1077"></a><b>1077</b></td><td valign="top" class="summaryTableCol">Expecting CaseLabel.
-
-	</td><td class="summaryTableLastCol">
-	The compiler expected a <code>case</code> statement at this point in the switch block. The 	following switch block incorrectly includes a call to <code>print</code> before the first <code>case</code> statement:
-
-<pre>switch(x)
-{
-trace(2);
-case 0:  trace(0); 
-break
-}</pre>
-	
     </td>
 </tr>
 <tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1078"></a><b>1078</b></td><td valign="top" class="summaryTableCol">Label must be a simple identifier.</td><td class="summaryTableLastCol">&nbsp;</td>
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1065"></a><b>1065</b></td><td valign="top" class="summaryTableCol">Variable _ is not defined.
+  </td><td class="summaryTableLastCol">
+    You are using an undefined lexical reference. For example, in the following statements, the
+    statement <code>trace(x)</code> generates an error because <code>x</code> is undefined. However, the
+    statement <code>trace(y)</code> doesn't generate an error because <code>y</code> is defined:
+    <pre><code>trace("hello world")
+    trace(x) // x is undefined
+    var y
+    trace(y) // No error, y is defined.</code></pre>
+    </td>
 </tr>
 <tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1079"></a><b>1079</b></td><td valign="top" class="summaryTableCol">A super expression must have one operand.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1080"></a><b>1080</b></td><td valign="top" class="summaryTableCol">Expecting increment or decrement operator.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1082"></a><b>1082</b></td><td valign="top" class="summaryTableCol">Expecting a single expression within parentheses.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1083"></a><b>1083</b></td><td valign="top" class="summaryTableCol">Syntax error: _ is unexpected.
-
-</td><td class="summaryTableLastCol">
-	
-		The line of code is missing some information. In the following example,
-		some expression (such as another number) needs to be included after the final plus sign:
-
-		<pre>var sum:int = 1 + 2 + ;</pre>
-	
-	</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1084"></a><b>1084</b></td><td valign="top" class="summaryTableCol">Syntax error: expecting _ before _.
-</td><td class="summaryTableLastCol">
-	
-		The expression was unexpected at this point.
-		If the error says "Expecting right brace before end of program," a block of code
-		is missing a closing brace (&#125).
-
-		<p>If the error says "Expecting left parenthesis before _," you may have omitted a  
-		parenthesis from a conditional expression, as shown in the following example, which is intentionally incorrect: </p>
-
-		<pre><code>var fact:int = 1 * 2 * 3;
-if fact &gt; 2 {
-	var bigger:Boolean = true;
-}</code></pre>
-	
-	</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1086"></a><b>1086</b></td><td valign="top" class="summaryTableCol">Syntax error: expecting semicolon before _.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1087"></a><b>1087</b></td><td valign="top" class="summaryTableCol">Syntax error: extra characters found after end of program.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1093"></a><b>1093</b></td><td valign="top" class="summaryTableCol">Syntax error.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1094"></a><b>1094</b></td><td valign="top" class="summaryTableCol">Syntax error: A string literal must be terminated before the line break.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1095"></a><b>1095</b></td><td valign="top" class="summaryTableCol">Syntax error: A string literal must be terminated before the line break.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1097"></a><b>1097</b></td><td valign="top" class="summaryTableCol">Syntax error: input ended before reaching the closing quotation mark for a string literal.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1099"></a><b>1099</b></td><td valign="top" class="summaryTableCol">Syntax error.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1100"></a><b>1100</b></td><td valign="top" class="summaryTableCol">Syntax error: XML does not have matching begin and end tags.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1102"></a><b>1102</b></td><td valign="top" class="summaryTableCol">Cannot delete super descendants.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1103"></a><b>1103</b></td><td valign="top" class="summaryTableCol">Duplicate namespace definition.
-
-	</td><td class="summaryTableLastCol">
-	You defined the namespace more than once. Delete or modify the duplicate definition.
-	</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1105"></a><b>1105</b></td><td valign="top" class="summaryTableCol">Target of assignment must be a reference value.
-
-	</td><td class="summaryTableLastCol">
-	You can assign a value to a variable, but you cannot assign a value to another value. 
-	</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1106"></a><b>1106</b></td><td valign="top" class="summaryTableCol">Operand of increment must be a reference.
-	</td><td class="summaryTableLastCol">
-	The operand must be a variable, an element in an array, or a property of an object.
-	</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1107"></a><b>1107</b></td><td valign="top" class="summaryTableCol">Increment operand is invalid.
-
-	</td><td class="summaryTableLastCol">
-	The operand must be a variable, an element in an array, or a property of an object.
-	</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1108"></a><b>1108</b></td><td valign="top" class="summaryTableCol">Decrement operand is invalid.
-	</td><td class="summaryTableLastCol">
-	The operand must be a variable, an element in an array, or a property of an object.
-	</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1109"></a><b>1109</b></td><td valign="top" class="summaryTableCol">Expecting an expression.
-
-</td><td class="summaryTableLastCol">
-	
-		An expression is missing in a part of the code. For example, the following produces this
-		error (there is a condition missing from the <code>if</code> statement:
-
-<pre><code>var x = (5 &gt; 2) ? 
-trace(x)</code></pre>
-	
-	</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1110"></a><b>1110</b></td><td valign="top" class="summaryTableCol">Missing XML tag name.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1112"></a><b>1112</b></td><td valign="top" class="summaryTableCol">Possible infinite recursion due to this file include: _.
-
-	</td><td class="summaryTableLastCol">
-	A file that is included in the source being compiled contains other <code>include</code> statements that would cause an infinite loop. For example, the following files. a.as and 	b.as, generate this error because each file tries to include the other.
-	<p>
-	File a.as contains the following, which attempts to include the file b.as:</p>
-<pre>import foo.bar.baz;
-include "b.as"
-trace(2);</pre>
-	<p>File b.as contains the following, which attempts to include the file a.as:</p>
-	<pre>include "a.as"</pre>
-
-	</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1113"></a><b>1113</b></td><td valign="top" class="summaryTableCol">Circular type reference was detected in _.
-	</td><td class="summaryTableLastCol">
-	A class is trying to extend a superclass. For example, class A cannot extend class B if B inherits from A:
-<pre><code>class a extends b { }
-class b extends a { }</code></pre>
-	</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1114"></a><b>1114</b></td><td valign="top" class="summaryTableCol">The public attribute can only be used inside a package.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1115"></a><b>1115</b></td><td valign="top" class="summaryTableCol">The internal attribute can only be used inside a package.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1116"></a><b>1116</b></td><td valign="top" class="summaryTableCol">A user-defined namespace attribute can only be used at the top level of a class definition.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1118"></a><b>1118</b></td><td valign="top" class="summaryTableCol">Implicit coercion of a value with static type _ to a possibly unrelated type _.
-	</td><td class="summaryTableLastCol">You are using a value that is not of the expected type and no implicit coercion exists to convert it to the expected type.
-	<p>Perhaps you are using a supertype where a subtype is expected. For example:</p>
-<pre><code>class A {}
-var a:A = new A(); 
-class B extends A { function f() }
-var b : B = a // error</code></pre>
-	<p>The last statement generates an error because it attempts to assign an object of type A to a variable of type B.</p>
-	<p>Similarly, the following defines the <code>foo()</code> function, which takes a parameter of type B. The statement <code> foo(a);</code> 
-	generates an error because it attempts to use a parameter of type A:</p>
-<pre><code>function foo(x:B) { }
-foo(a);</code></pre>
-	<p>Also, the following statement generates an error because the returned value for 	<code>foo2()</code> must be type B:</p>
-	<pre><code>function foo2():B { return new A(); }</code></pre>
-	</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1119"></a><b>1119</b></td><td valign="top" class="summaryTableCol">Access of possibly undefined property _ through a reference with static type _.
-
-
-</td><td class="summaryTableLastCol">
-	
-		You are attempting to access a property that does not exist for the specified object. For example,
-		the following code generates this error because an int object does not have a property named
-		<code>assortment</code>:
-
-<pre><code>var i:int = 44;
-var str:String = i.assortment;</code></pre>
-
-		This error appears only when the compiler is running in strict mode.
-	
-	</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1120"></a><b>1120</b></td><td valign="top" class="summaryTableCol">Access of undefined property _.
-
-</td><td class="summaryTableLastCol">
-	
-		You are attempting to access an undefined variable. For example, if the variable
-		<code>huh</code> has not been defined, a call to it generates this error:
-
-<pre><code>huh = 55;</code></pre>
-
-		This error can appear only when the compiler is running in strict mode.
-	
-	</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1121"></a><b>1121</b></td><td valign="top" class="summaryTableCol">A getter definition must have no parameters.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1122"></a><b>1122</b></td><td valign="top" class="summaryTableCol">A setter definition must have exactly one parameter.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1123"></a><b>1123</b></td><td valign="top" class="summaryTableCol">A setter definition cannot have optional parameters.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1124"></a><b>1124</b></td><td valign="top" class="summaryTableCol">Return type of a getter definition must not be void.
-
-	</td><td class="summaryTableLastCol">
-	A getter function simulates a variable. Because variables cannot be of type void, you cannot declare getter functions to return type void.
-	</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1125"></a><b>1125</b></td><td valign="top" class="summaryTableCol">Methods defined in an interface must not have a body.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1126"></a><b>1126</b></td><td valign="top" class="summaryTableCol">Function does not have a body.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1127"></a><b>1127</b></td><td valign="top" class="summaryTableCol">Attribute _ was specified multiple times.
-
-	</td><td class="summaryTableLastCol">
-	You specified an attribute more than once in the same statement. For example, the statement <code>public static public var x;</code> generates 
-	this error because it specifies that the variable <code>x</code> is public twice. Delete duplicate declarations.
-	</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1129"></a><b>1129</b></td><td valign="top" class="summaryTableCol">Duplicate interface definition: _.
-
-	</td><td class="summaryTableLastCol">
-	Change or delete the duplicate definitions.
-	</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1130"></a><b>1130</b></td><td valign="top" class="summaryTableCol">A constructor cannot specify a return type.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1131"></a><b>1131</b></td><td valign="top" class="summaryTableCol">Classes must not be nested.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1132"></a><b>1132</b></td><td valign="top" class="summaryTableCol">The attribute final can only be used on a method defined in a class.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1133"></a><b>1133</b></td><td valign="top" class="summaryTableCol">The native attribute can only be used with function definitions.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1134"></a><b>1134</b></td><td valign="top" class="summaryTableCol">The dynamic attribute can only be used with class definitions.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1135"></a><b>1135</b></td><td valign="top" class="summaryTableCol">Syntax error: _ is not a valid type.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1136"></a><b>1136</b></td><td valign="top" class="summaryTableCol">Incorrect number of arguments.  Expected _.
-
-	</td><td class="summaryTableLastCol">
-	The function expects a different number of arguments than those you provided. For example, the 	following defines function <code>goo</code>, which has two arguments:
-<pre>class A { static function goo(x:int,y:int) 
-{ return(x+y); } }</pre>
-	<p>The following statement would generate an error because it provides three arguments:</p>
-<pre>A.goo(1,2,3);</pre>
-	</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1137"></a><b>1137</b></td><td valign="top" class="summaryTableCol">Incorrect number of arguments.  Expected no more than _.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1138"></a><b>1138</b></td><td valign="top" class="summaryTableCol">Required parameters are not permitted after optional parameters.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1139"></a><b>1139</b></td><td valign="top" class="summaryTableCol">Variable declarations are not permitted in interfaces.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1140"></a><b>1140</b></td><td valign="top" class="summaryTableCol">Parameters specified after the ...rest parameter definition keyword can only be an Array data type.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1141"></a><b>1141</b></td><td valign="top" class="summaryTableCol">A class can only extend another class, not an interface.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1142"></a><b>1142</b></td><td valign="top" class="summaryTableCol">An interface can only extend other interfaces, but _ is a class.
-	</td><td class="summaryTableLastCol">
-	You are attempting to have the interface extend a class. An interface can only extend another 	interface.
-	</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1143"></a><b>1143</b></td><td valign="top" class="summaryTableCol">The override attribute can only be used on a method defined in a class.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1144"></a><b>1144</b></td><td valign="top" class="summaryTableCol">Interface method _ in namespace _ is implemented with an incompatible signature in class _.
-
-	</td><td class="summaryTableLastCol">
-	Method signatures must match exactly.
-	</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1145"></a><b>1145</b></td><td valign="top" class="summaryTableCol">Native methods cannot have a body.
-	</td><td class="summaryTableLastCol">
-	You cannot use <code>native</code> because it is a reserved keyword.
-	</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1146"></a><b>1146</b></td><td valign="top" class="summaryTableCol">A constructor cannot be a getter or setter method.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1147"></a><b>1147</b></td><td valign="top" class="summaryTableCol">An AS source file was not specified.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1149"></a><b>1149</b></td><td valign="top" class="summaryTableCol">The return statement cannot be used in static initialization code.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1150"></a><b>1150</b></td><td valign="top" class="summaryTableCol">The protected attribute can only be used on class property definitions.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1151"></a><b>1151</b></td><td valign="top" class="summaryTableCol">A conflict exists with definition _ in namespace _.
-
-	</td><td class="summaryTableLastCol">
-	You cannot declare more than one variable with the same identifier name within the same scope unless all such variables are declared to be of 
-	the same type. In ActionScript 3.0, different code 	blocks (such as those used in two <code>for</code> loops in the same function definition) are 	considered to be in the same scope. 
-	<p>The following code example correctly casts the variable <code>x</code> as the same type:</p>
-<pre><code>function test()
-{
-	var x:int = 3;
-	for(var x:int = 33; x &lt; 55; x++)
-	trace(x);
-	for(var x:int = 11; x &lt; 33; x++)
-	trace(x)
-}</code></pre>
-	<p>The following code example generates an error because the type casting in the variable declaration and the <code>for</code> loops are different:</p>
-<pre><code>function test()
-{
-	var x:String = "The answer is";
-	for(var x:int = 33; x &lt; 55; x++) // error
-	trace(x);
-	for(var x:unit = 11; x &lt; 33; x++) // error
-	trace(x)
-}</code></pre>
-</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1152"></a><b>1152</b></td><td valign="top" class="summaryTableCol"> A conflict exists with inherited definition _ in namespace _.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1153"></a><b>1153</b></td><td valign="top" class="summaryTableCol">A constructor can only be declared public.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1154"></a><b>1154</b></td><td valign="top" class="summaryTableCol">Only one of public, private, protected, or internal can be specified on a definition.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1155"></a><b>1155</b></td><td valign="top" class="summaryTableCol">Accessors cannot be nested inside other functions.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1156"></a><b>1156</b></td><td valign="top" class="summaryTableCol">Interfaces cannot be instantiated with the new operator.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1157"></a><b>1157</b></td><td valign="top" class="summaryTableCol">Interface members cannot be declared public, private, protected, or internal.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1158"></a><b>1158</b></td><td valign="top" class="summaryTableCol">Syntax error: missing left brace ({) before the function body.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1159"></a><b>1159</b></td><td valign="top" class="summaryTableCol">The return statement cannot be used in package initialization code.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1160"></a><b>1160</b></td><td valign="top" class="summaryTableCol">The native attribute cannot be used in interface definitions.
-	</td><td class="summaryTableLastCol">
-	You cannot use <code>native</code> because it is a reserved keyword.
-	</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1162"></a><b>1162</b></td><td valign="top" class="summaryTableCol">Only one namespace attribute can be used per definition.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1163"></a><b>1163</b></td><td valign="top" class="summaryTableCol">Method _ conflicts with definition inherited from interface _.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1165"></a><b>1165</b></td><td valign="top" class="summaryTableCol">Interface attribute _ is invalid.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1166"></a><b>1166</b></td><td valign="top" class="summaryTableCol">Namespace declarations are not permitted in interfaces.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1167"></a><b>1167</b></td><td valign="top" class="summaryTableCol">Class _ implements interface _ multiple times.
-
-	</td><td class="summaryTableLastCol">
-	The class implements the same interface more than once. For example, the following generates this error because 
-	class C implements interface A twice:
-
-<pre><code>interface A {  public function f();  };
-class C implements A,A {
-public function f() { trace("f"); }
-}</code></pre>
-	
-	<p>The correct implementing statement should be <code> class C implements A {</code>.</p>
-	</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1168"></a><b>1168</b></td><td valign="top" class="summaryTableCol">Illegal assignment to function _.
-
-	</td><td class="summaryTableLastCol">
-	You are attempting to redefine a function. For example, the following defines the function 	<code>topLevel()</code> 
-	to print the word "top". The second statement generates an error because it assigns a different return value to the function:
-<pre><code>function topLevel() { trace("top"); }
-topLevel = function() { trace("replacement works in ~");} // error</code></pre>
-	</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1169"></a><b>1169</b></td><td valign="top" class="summaryTableCol">Namespace attributes are not permitted on interface methods.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1170"></a><b>1170</b></td><td valign="top" class="summaryTableCol">Function does not return a value.
-
-	</td><td class="summaryTableLastCol">
-	Every possible control flow in a function must return a value whenever the return type is 	something other than void. The following function 
-	<code>f(x)</code> does not generate an error because the <code>if..else</code> statement always returns a value:
-
-<pre><code>function f(x):int
-{
-if (x)
-    	return 2;
-else
-    	return 3;
-} // no error</code></pre>
-
-<p>However, the function <code>g(x)</code> below generates the error because the <code>switch</code> statement does not always 
-return a value.</p>
-<pre><code>function g(x:int):int
-{
-switch(x)
-{
-      	case 1: return 1;
-      	case 2: return 2:
-}
-// return 2;//uncomment to remove the error
-}</code></pre>
-
-	<p>This checking is enabled only when the function declares a return type other than void. </p>
-	</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1171"></a><b>1171</b></td><td valign="top" class="summaryTableCol">A namespace initializer must be either a literal string or another namespace.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1172"></a><b>1172</b></td><td valign="top" class="summaryTableCol">Definition _ could not be found.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1173"></a><b>1173</b></td><td valign="top" class="summaryTableCol">Label definition is invalid.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1176"></a><b>1176</b></td><td valign="top" class="summaryTableCol">Comparison between a value with static type _ and a possibly unrelated type _.
-</td><td class="summaryTableLastCol">This error is enabled in strict mode.</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1177"></a><b>1177</b></td><td valign="top" class="summaryTableCol">The return statement cannot be used in global initialization code.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1178"></a><b>1178</b></td><td valign="top" class="summaryTableCol">Attempted access of inaccessible property _ through a reference with static type _.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1180"></a><b>1180</b></td><td valign="top" class="summaryTableCol">Call to a possibly undefined method _.
-</td><td class="summaryTableLastCol">This error appears only when the compiler is running in strict mode.</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1181"></a><b>1181</b></td><td valign="top" class="summaryTableCol">Forward reference to base class _.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1182"></a><b>1182</b></td><td valign="top" class="summaryTableCol">Package cannot be used as a value: _.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1184"></a><b>1184</b></td><td valign="top" class="summaryTableCol">Incompatible default value of type _ where _ is expected.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1185"></a><b>1185</b></td><td valign="top" class="summaryTableCol">The switch has more than one default, but only one default is allowed.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1188"></a><b>1188</b></td><td valign="top" class="summaryTableCol">Illegal assignment to class _.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1189"></a><b>1189</b></td><td valign="top" class="summaryTableCol">Attempt to delete the fixed property _.  Only dynamically defined properties can be deleted.
-</td><td class="summaryTableLastCol">Delete removes dynamically defined properties from an object.  Declared properties of a class can not be deleted.  This error appears only when the compiler is running in strict mode.</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1190"></a><b>1190</b></td><td valign="top" class="summaryTableCol">Base class was not found or is not a compile-time constant.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1191"></a><b>1191</b></td><td valign="top" class="summaryTableCol">Interface was not found or is not a compile-time constant.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1192"></a><b>1192</b></td><td valign="top" class="summaryTableCol">The static attribute is not allowed on namespace definitions.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1193"></a><b>1193</b></td><td valign="top" class="summaryTableCol">Interface definitions must not be nested within class or other interface definitions.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1194"></a><b>1194</b></td><td valign="top" class="summaryTableCol">The prototype attribute is invalid.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1195"></a><b>1195</b></td><td valign="top" class="summaryTableCol">Attempted access of inaccessible method _ through a reference with static type _.
-		</td><td class="summaryTableLastCol">You are either calling a private method from another class, or calling a method defined in a namespace that is not in use.  If you are calling a method defined in an unused namespace, add a <code>use</code> statement for the required namespace.
-	</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1196"></a><b>1196</b></td><td valign="top" class="summaryTableCol">Syntax error: expecting an expression after the throw.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1197"></a><b>1197</b></td><td valign="top" class="summaryTableCol">The class _ cannot extend _ since both are associated with library symbols or the main timeline.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1198"></a><b>1198</b></td><td valign="top" class="summaryTableCol">Attributes are not allowed on package definition.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1199"></a><b>1199</b></td><td valign="top" class="summaryTableCol">Internal error: _.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1200"></a><b>1200</b></td><td valign="top" class="summaryTableCol">Syntax error: invalid for-in initializer, only 1 expression expected.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1201"></a><b>1201</b></td><td valign="top" class="summaryTableCol">A super statement cannot occur after a this, super, return, or throw statement.</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1202"></a><b>1202</b></td><td valign="top" class="summaryTableCol">Access of undefined property _ in package _.
-
-</td><td class="summaryTableLastCol">
-	
-		You are attempting to access an undefined variable in a package. For example, if the variable
-		<code>p.huh</code> has not been defined, a call to it generates this error:
-
-<pre><code>p.huh = 55;</code></pre>
-
-		This error can only appear when the compiler is running in strict mode.
-	
-</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1203"></a><b>1203</b></td><td valign="top" class="summaryTableCol">No default constructor found in base class _.
-    </td><td class="summaryTableLastCol">You must explicitly call the constructor of the base class with a super() statement if it has 1 or more required arguments.</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1204"></a><b>1204</b></td><td valign="top" class="summaryTableCol">/* found without matching */ .
-</td><td class="summaryTableLastCol">
-	
-		The characters '/*' where found, which indicate the beginning of a comment, but the corresponding characters, '*/', which indicate the end of the comment block, were not found.
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1066"></a><b>1066</b></td><td valign="top" class="summaryTableCol">The form function('function body') is not supported.
+  </td><td class="summaryTableLastCol">
+    Unlike JavaScript, Flash does not compile code on-the-fly using <code>eval()</code> and
+    <code>function()</code>.  Thus, calling these as a constructor in ActionScript 3.0 generates this error.
     </td>
 </tr>
 <tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1205"></a><b>1205</b></td><td valign="top" class="summaryTableCol">Syntax Error: expecting a left brace({)or string literal("").</td><td class="summaryTableLastCol">&nbsp;</td>
-</tr>
-<tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1206"></a><b>1206</b></td><td valign="top" class="summaryTableCol">A super statement can be used only as the last item in a constructor initializer list.
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1067"></a><b>1067</b></td><td valign="top" class="summaryTableCol">Native method _ has illegal method body.
 </td><td class="summaryTableLastCol">
-		You cannot use the <code>super</code> statement within a constructor. You can 
-		use the <code>super</code> statement only as the last item in the constructor initializer list.
-	
-	</td>
-</tr>
-<tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1207"></a><b>1207</b></td><td valign="top" class="summaryTableCol">The this keyword can not be used in property initializers.
-    </td><td class="summaryTableLastCol">
-	
-		You cannot use the <code>this</code> keyword within a property initializer.
-	
-	</td>
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
 </tr>
 <tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1208"></a><b>1208</b></td><td valign="top" class="summaryTableCol">The initializer for a configuration value must be a compile time constant.
-    </td><td class="summaryTableLastCol">
-	
-		The initializer of a configuration value must be a value known at compile time.  The initializer may be a constant string, number, or boolean, or 
-		a reference to another previously defined configuration value.
-	
-	</td>
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1068"></a><b>1068</b></td><td valign="top" class="summaryTableCol">_ and _ cannot be reconciled.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
 </tr>
 <tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1209"></a><b>1209</b></td><td valign="top" class="summaryTableCol">A configuration variable may only be declared const.
-    </td><td class="summaryTableLastCol">
-	
-		When defining a configuration variable, it must be declared as const.
-	
-	</td>
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1069"></a><b>1069</b></td><td valign="top" class="summaryTableCol">Property _ not found on _ and there is no default value.
+  </td><td class="summaryTableLastCol">
+    You are referencing an undefined property on a non-dynamic class instance. For example, the following generates this error when it references property
+    <code>x</code>, which is not defined and cannot be created dynamically:
+    <pre><code>class A {} // sealed class, not dynamic
+    trace(new A().x) // no property x defined on A, and A is not dynamic</code></pre>
+    </td>
 </tr>
 <tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1210"></a><b>1210</b></td><td valign="top" class="summaryTableCol">A configuration value must be declared at the top level of a program or package.
-    </td><td class="summaryTableLastCol">
-	
-		A configuration value must be declared at the top level of a program or package.
-	
-	</td>
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1070"></a><b>1070</b></td><td valign="top" class="summaryTableCol">Method _ not found on _
+  </td><td class="summaryTableLastCol">
+    You are using a <code>super</code> statement to call a function, but the function doesn't exist in the super class.
+    For example, the following code generates the error:    <pre><code>class A() {}
+class B extends A {
+  function f() { trace(super.f()); } // error 1070, there is no f on A
+}</code></pre>
+    </td>
 </tr>
 <tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1211"></a><b>1211</b></td><td valign="top" class="summaryTableCol">Namespace _ conflicts with a configuration namespace.
-    </td><td class="summaryTableLastCol">
-	
-		A namespace may not have the same name as a configuration namespace.
-	
-	</td>
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1071"></a><b>1071</b></td><td valign="top" class="summaryTableCol">Function _ has already been bound to _.</td><td class="summaryTableLastCol">&nbsp;</td>
 </tr>
 <tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1212"></a><b>1212</b></td><td valign="top" class="summaryTableCol">Precision must be an integer between 1 and 34.</td><td class="summaryTableLastCol">&nbsp;</td>
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1072"></a><b>1072</b></td><td valign="top" class="summaryTableCol">Disp_id 0 is illegal.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
 </tr>
 <tr class="prow0">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1214"></a><b>1214</b></td><td valign="top" class="summaryTableCol">Incompatible Version: can not reference definition _ introduced in version _ from code with version _.</td><td class="summaryTableLastCol">&nbsp;</td>
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1073"></a><b>1073</b></td><td valign="top" class="summaryTableCol">Non-override method _ replaced because of duplicate disp_id _.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
 </tr>
 <tr class="prow1">
-<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1215"></a><b>1215</b></td><td valign="top" class="summaryTableCol">Invalid initialization: conversion to type _ loses data.</td><td class="summaryTableLastCol">&nbsp;</td>
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1074"></a><b>1074</b></td><td valign="top" class="summaryTableCol">Illegal write to read-only property _ on _.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1075"></a><b>1075</b></td><td valign="top" class="summaryTableCol">Math is not a function.
+  </td><td class="summaryTableLastCol">
+    You are trying to call <code>math()</code> as a function, but the Math class is a class with static methods.
+    </td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1076"></a><b>1076</b></td><td valign="top" class="summaryTableCol">Math is not a constructor.
+  </td><td class="summaryTableLastCol">
+    You can not instantiate the Math class.
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1077"></a><b>1077</b></td><td valign="top" class="summaryTableCol">Illegal read of write-only property _ on _.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1078"></a><b>1078</b></td><td valign="top" class="summaryTableCol">Illegal opcode/multiname combination: _&lt;_&gt;.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1079"></a><b>1079</b></td><td valign="top" class="summaryTableCol">Native methods are not allowed in loaded code.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1080"></a><b>1080</b></td><td valign="top" class="summaryTableCol">Illegal value for namespace.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1081"></a><b>1081</b></td><td valign="top" class="summaryTableCol">Property _ not found on _ and there is no default value.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1082"></a><b>1082</b></td><td valign="top" class="summaryTableCol">No default namespace has been set.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1083"></a><b>1083</b></td><td valign="top" class="summaryTableCol">The prefix "_" for element "_" is not bound.
+</td><td class="summaryTableLastCol">
+    An attribute name or element name has a prefix but no matching namespace was
+    found. This statement generates an error because there is no <code>foo</code>
+    namespace to match <code>foo:x</code>:<pre/>&lt;foo:x xmlns:clowns='http://circuscenter.org'&gt;</pre>
+        </td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1084"></a><b>1084</b></td><td valign="top" class="summaryTableCol">Element or attribute ("_") does not match QName production: QName::=(NCName':')?NCName.
+</td><td class="summaryTableLastCol">
+    You have <code>foo: </code> or <code>:foo</code> as an element or attribute name, but there is nothing
+    on the other side of the colon.
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1085"></a><b>1085</b></td><td valign="top" class="summaryTableCol">The element type "_" must be terminated by the matching end-tag "&lt;/_&gt;".</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1086"></a><b>1086</b></td><td valign="top" class="summaryTableCol">The _ method only works on lists containing one item.
+</td><td class="summaryTableLastCol">
+    The XMLList class propagates the XML-specific functions to one child if it has only one
+    item in its list. If more than one item is in the list, the routines fail with this
+    error. This happens for the following XMLList functions that mimic XML functions:
+    <p><code>addNamespace</code>, <code>appendChild</code>,  <code>childIndex</code>,
+    <code>inScopeNamespaces</code>,  <code>insertChildAfter</code>,  <code>insertChildBefore</code>,
+    <code>name</code>,  <code>namespace</code>,  <code>localName</code>,  <code>namespaceDeclarations</code>,
+    <code>nodeKind</code>,  <code>prependChild</code>,  <code>removeNamespace</code>,  <code>replace</code>,
+    <code>setChildren</code>,  <code>setLocalName</code>,  <code>setName</code>,  and <code>setNamespace.
+
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1087"></a><b>1087</b></td><td valign="top" class="summaryTableCol">Assignment to indexed XML is not allowed.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1088"></a><b>1088</b></td><td valign="top" class="summaryTableCol">The markup in the document following the root element must be well-formed.
+</td><td class="summaryTableLastCol">
+    These are possible causes of this error:
+    <ul>
+    <li>Parsing an XMLList style object as XML</li>
+    <li>Misbalanced strings</li>
+    </ul>
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1089"></a><b>1089</b></td><td valign="top" class="summaryTableCol">Assignment to lists with more than one item is not supported.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1090"></a><b>1090</b></td><td valign="top" class="summaryTableCol">XML parser failure: element is malformed.
+</td><td class="summaryTableLastCol">
+    An element name is malformed. This example of an element name is malformed because a
+    trailing right angle bracket <code>></code> is missing:
+
+    <pre>&lt;a/&gt;&lt;b&gt;&lt;/b</pre>    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1091"></a><b>1091</b></td><td valign="top" class="summaryTableCol">XML parser failure: Unterminated CDATA section.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1092"></a><b>1092</b></td><td valign="top" class="summaryTableCol">XML parser failure: Unterminated XML declaration.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1093"></a><b>1093</b></td><td valign="top" class="summaryTableCol">XML parser failure: Unterminated DOCTYPE declaration.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1094"></a><b>1094</b></td><td valign="top" class="summaryTableCol">XML parser failure: Unterminated comment.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1095"></a><b>1095</b></td><td valign="top" class="summaryTableCol">XML parser failure: Unterminated attribute.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1096"></a><b>1096</b></td><td valign="top" class="summaryTableCol">XML parser failure: Unterminated element.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1097"></a><b>1097</b></td><td valign="top" class="summaryTableCol">XML parser failure: Unterminated processing instruction.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1098"></a><b>1098</b></td><td valign="top" class="summaryTableCol">Illegal prefix _ for no namespace.
+</td><td class="summaryTableLastCol">
+    The namespace constructor throws this error if you try to pass in an empty URI with a
+    non-empty prefix as in this example:
+
+<pre>ns = new Namespace ("prefix", "");
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1100"></a><b>1100</b></td><td valign="top" class="summaryTableCol">Cannot supply flags when constructing one RegExp from another.
+  </td><td class="summaryTableLastCol">
+    Creating a new regular expression from an existing one also copies its flags. To create a regular expression with
+    different flags, use the <code>new</code> operator and set the flags as desired. For example, this statement
+    creates a regular expression and specifies flag settings:
+    <pre><code>var re:RegExp = new RegExp("ali", /s)</code></pre>
+    Alternatively, this statement creates a regular expression that has the same flags as re:
+    <pre><code>var re2:RegExp = new RegExp(re, ...)</code></pre>    </td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1101"></a><b>1101</b></td><td valign="top" class="summaryTableCol">Cannot verify method _ with unknown scope.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1102"></a><b>1102</b></td><td valign="top" class="summaryTableCol">Illegal default value for type _.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1103"></a><b>1103</b></td><td valign="top" class="summaryTableCol">Class _ cannot extend final base class.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1104"></a><b>1104</b></td><td valign="top" class="summaryTableCol">Attribute "_" was already specified for element "_".</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1107"></a><b>1107</b></td><td valign="top" class="summaryTableCol">The ABC data is corrupt, attempt to read out of bounds.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1108"></a><b>1108</b></td><td valign="top" class="summaryTableCol">The OP_newclass opcode was used with the incorrect base class.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1109"></a><b>1109</b></td><td valign="top" class="summaryTableCol">Attempt to directly call unbound function _ from method _.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1110"></a><b>1110</b></td><td valign="top" class="summaryTableCol">_ cannot extend _.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1111"></a><b>1111</b></td><td valign="top" class="summaryTableCol">_ cannot implement _.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1112"></a><b>1112</b></td><td valign="top" class="summaryTableCol">Argument count mismatch on class coercion.  Expected 1, got _.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1113"></a><b>1113</b></td><td valign="top" class="summaryTableCol">OP_newactivation used in method without NEED_ACTIVATION flag.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1114"></a><b>1114</b></td><td valign="top" class="summaryTableCol">OP_getglobalslot or OP_setglobalslot used with no global scope.
+</td><td class="summaryTableLastCol">
+        See the <a href="#note">note</a> at the bottom of this table.&#42;
+    </td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1115"></a><b>1115</b></td><td valign="top" class="summaryTableCol">_ is not a constructor.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1116"></a><b>1116</b></td><td valign="top" class="summaryTableCol">second argument to Function.prototype.apply must be an array.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1117"></a><b>1117</b></td><td valign="top" class="summaryTableCol">Invalid XML name: _.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1118"></a><b>1118</b></td><td valign="top" class="summaryTableCol">Illegal cyclical loop between nodes.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1119"></a><b>1119</b></td><td valign="top" class="summaryTableCol">Delete operator is not supported with operand of type _.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1120"></a><b>1120</b></td><td valign="top" class="summaryTableCol">Cannot delete property _ on _.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1121"></a><b>1121</b></td><td valign="top" class="summaryTableCol">Method _ has a duplicate method body.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1122"></a><b>1122</b></td><td valign="top" class="summaryTableCol">Interface method _ has illegal method body.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1123"></a><b>1123</b></td><td valign="top" class="summaryTableCol">Filter operator not supported on type _.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1124"></a><b>1124</b></td><td valign="top" class="summaryTableCol">OP_hasnext2 requires object and index to be distinct registers.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1125"></a><b>1125</b></td><td valign="top" class="summaryTableCol">The index _ is out of range _.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1126"></a><b>1126</b></td><td valign="top" class="summaryTableCol">Cannot change the length of a fixed Vector.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1127"></a><b>1127</b></td><td valign="top" class="summaryTableCol">Type application attempted on a non-parameterized type.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1128"></a><b>1128</b></td><td valign="top" class="summaryTableCol">Incorrect number of type parameters for _. Expected _, got _.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1129"></a><b>1129</b></td><td valign="top" class="summaryTableCol">Cyclic structure cannot be converted to JSON string.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1131"></a><b>1131</b></td><td valign="top" class="summaryTableCol">Replacer argument to JSON stringifier must be an array or a two parameter function.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1132"></a><b>1132</b></td><td valign="top" class="summaryTableCol">Invalid JSON parse input.</td><td class="summaryTableLastCol">&nbsp;</td>
 </tr>
 <tr class="prow0">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1502"></a><b>1502</b></td><td valign="top" class="summaryTableCol">A script has executed for longer than the default timeout period of 15 seconds.
-		</td><td class="summaryTableLastCol">
-		A script executed after the timeout period. (The default timeout period is 15 seconds.) After this error occurs, the
-		script can continue to execute for 15 seconds more, after which the script terminates and throws run-time error number 1503 (A script failed to exit after 30 seconds and was terminated.)
-		</td>
+        </td><td class="summaryTableLastCol">
+        A script executed after the timeout period. (The default timeout period is 15 seconds.) After this error occurs, the
+        script can continue to execute for 15 seconds more, after which the script terminates and throws run-time error number 1503 (A script failed to exit after 30 seconds and was terminated.)
+    </td>
 </tr>
 <tr class="prow1">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1503"></a><b>1503</b></td><td valign="top" class="summaryTableCol">A script failed to exit after 30 seconds and was terminated.
-		</td><td class="summaryTableLastCol">
-		The script was still executing after 30 seconds. Flash Player first throws run-time error number 1502 (A script has executed for longer than the default timeout period of 15 seconds.) if the script executed more than 15
-		seconds, which is the default timeout period. This error occurs 15 seconds after Error 1502 occurs.
-		</td>
+      </td><td class="summaryTableLastCol">
+      The script was still executing after 30 seconds. Flash Player first throws run-time error number 1502 (A script has executed for longer than the default timeout period of 15 seconds.) if the script executed more than 15
+      seconds, which is the default timeout period. This error occurs 15 seconds after Error 1502 occurs.
+    </td>
 </tr>
 <tr class="prow0">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1507"></a><b>1507</b></td><td valign="top" class="summaryTableCol">Argument _ cannot be null.</td><td class="summaryTableLastCol">&nbsp;</td>
 </tr>
 <tr class="prow1">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1508"></a><b>1508</b></td><td valign="top" class="summaryTableCol">The value specified for argument _ is invalid.
-		</td><td class="summaryTableLastCol">
-		You are possibly trying to pass the wrong data type. For example, the code
-		<pre><code>public function doSomething(const:int):void {}
-this ["doSomething"] ("str")</code></pre>
-		generates an error at runtime because <code>doSomething</code> is cast as an int data type.
-		</td>
+  </td><td class="summaryTableLastCol">
+    You are possibly trying to pass the wrong data type. For example, the code
+    <pre><code>public function doSomething(const:int):void {
+    }
+    this ["doSomething"] ("str")</code></pre>
+    generates an error at runtime because <code>doSomething</code> is cast as an int data type. </td>
 </tr>
 <tr class="prow0">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1510"></a><b>1510</b></td><td valign="top" class="summaryTableCol">When the callback argument is a method of a class, the optional this argument must be null.</td><td class="summaryTableLastCol">&nbsp;</td>
@@ -1101,6 +845,72 @@ this ["doSomething"] ("str")</code></pre>
 </tr>
 <tr class="prow1">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="1521"></a><b>1521</b></td><td valign="top" class="summaryTableCol">Only the worker's parent may call start.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="2004"></a><b>2004</b></td><td valign="top" class="summaryTableCol">One of the parameters is invalid.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="2006"></a><b>2006</b></td><td valign="top" class="summaryTableCol">The supplied index is out of bounds.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="2007"></a><b>2007</b></td><td valign="top" class="summaryTableCol">Parameter _ must be non-null.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="2008"></a><b>2008</b></td><td valign="top" class="summaryTableCol">Parameter _ must be one of the accepted values.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="2012"></a><b>2012</b></td><td valign="top" class="summaryTableCol">_ class cannot be instantiated.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="2030"></a><b>2030</b></td><td valign="top" class="summaryTableCol">End of file was encountered.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="2058"></a><b>2058</b></td><td valign="top" class="summaryTableCol">There was an error decompressing the data.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="2085"></a><b>2085</b></td><td valign="top" class="summaryTableCol">Parameter _ must be non-empty string.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="2088"></a><b>2088</b></td><td valign="top" class="summaryTableCol">The Proxy class does not implement getProperty. It must be overridden by a subclass.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="2089"></a><b>2089</b></td><td valign="top" class="summaryTableCol">The Proxy class does not implement setProperty. It must be overridden by a subclass.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="2090"></a><b>2090</b></td><td valign="top" class="summaryTableCol">The Proxy class does not implement callProperty. It must be overridden by a subclass.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="2091"></a><b>2091</b></td><td valign="top" class="summaryTableCol">The Proxy class does not implement hasProperty. It must be overridden by a subclass.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="2092"></a><b>2092</b></td><td valign="top" class="summaryTableCol">The Proxy class does not implement deleteProperty. It must be overridden by a subclass.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="2093"></a><b>2093</b></td><td valign="top" class="summaryTableCol">The Proxy class does not implement getDescendants. It must be overridden by a subclass.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="2105"></a><b>2105</b></td><td valign="top" class="summaryTableCol">The Proxy class does not implement nextNameIndex. It must be overridden by a subclass.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="2106"></a><b>2106</b></td><td valign="top" class="summaryTableCol">The Proxy class does not implement nextName. It must be overridden by a subclass.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="2107"></a><b>2107</b></td><td valign="top" class="summaryTableCol">The Proxy class does not implement nextValue. It must be overridden by a subclass.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="2108"></a><b>2108</b></td><td valign="top" class="summaryTableCol">The value _ is not a valid Array length.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="2173"></a><b>2173</b></td><td valign="top" class="summaryTableCol">Unable to read object in stream.  The class _ does not implement flash.utils.IExternalizable but is aliased to an externalizable class.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="3735"></a><b>3735</b></td><td valign="top" class="summaryTableCol">This API cannot accept shared ByteArrays.</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow0">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="3806"></a><b>3806</b></td><td valign="top" class="summaryTableCol">ByteArray.shareable is no longer supported. Learn more at https://www.adobe.com/go/fp-spectre</td><td class="summaryTableLastCol">&nbsp;</td>
+</tr>
+<tr class="prow1">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="3807"></a><b>3807</b></td><td valign="top" class="summaryTableCol">Worker.start has been disabled by the user. Learn more at https://www.adobe.com/go/fp-spectre</td><td class="summaryTableLastCol">&nbsp;</td>
 </tr>
 <tr class="prow0">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableSecondCol"><a name="2000"></a><b>2000</b></td><td valign="top" class="summaryTableCol">No active security context.</td><td class="summaryTableLastCol">&nbsp;</td>
@@ -3072,11 +2882,11 @@ b.addChild(a);</pre>
 <p></p>
 <div class="feedbackLink">
 <center>
-<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Sat Jan 11 2025, 8:31 AM GMT) : Run-Time Errors">Submit Feedback</a>
+<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Mon Jun 30 2025, 11:01 AM GMT+01:00) : Run-Time Errors">Submit Feedback</a>
 </center>
 </div>
-<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Sat Jan 11 2025, 8:31 AM GMT<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
+<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Mon Jun 30 2025, 11:01 AM GMT+01:00<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
 </div>
 </div>
 </body>
-</html><!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Sat Jan 11 2025, 8:31 AM GMT <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->
+</html><!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Mon Jun 30 2025, 11:01 AM GMT+01:00 <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->


### PR DESCRIPTION
Github-3720: Adding avm2.intrincis.memory and iteration packages
Github-3846: Adding event documentation into Stage3D Texture classes
Github-3846: Updating TEXTURE_READY event documentation
Github-3866: Correcting ByteArray.shareable documentation
Github-3870: Adding 'removeChildren()' to causes of DisplayObject removed events
Github-3874: Missing closing bracket for 'MessageChannel::send()' description