### PR TITLE
Feature/adt adl docs update

### DIFF
--- a/docs/building/air-debug-launcher.md
+++ b/docs/building/air-debug-launcher.md
@@ -32,9 +32,10 @@ Where `application.xml` is the application descriptor file for the application.
 The full syntax for the ADL is:
 
 ```
-adl     [-runtime runtime-directory]
+adl [-runtime runtime-directory]
     [-pubid publisher-id]
     [-nodebug]
+    [-cmd]
     [-atlogin]
     [-profile profileName]
     [-screensize value]
@@ -61,6 +62,12 @@ As of AIR 1.5.3, a Publisher ID is no longer automatically computed and assigned
 ### `-nodebug`
 
 Turns off debugging support. If used, the application process cannot connect to the Flash debugger and dialogs for unhandled exceptions are suppressed. (However, trace statements still print to the console window.) Turning off debugging allows your application to run a little faster and also emulates the execution mode of an installed application more closely.
+
+### `-cmd`
+
+Launches the application as a command-line app. This can be used for applications that do not need/want to have a graphical user interface; the 'stage' object will be null for this and there is no concept of a display list.
+
+Command-line applications can use methods such as [System.output()](https://airsdk.dev/reference/actionscript/3.0/flash/system/System.html#output()) and [System.input()](https://airsdk.dev/reference/actionscript/3.0/flash/system/System.html#input()) to interact with the user.
 
 ### `-atlogin`
 

--- a/docs/building/air-developer-tool/commands/certificate.md
+++ b/docs/building/air-developer-tool/commands/certificate.md
@@ -40,7 +40,7 @@ The number of years that the certificate will be valid. If not specified a valid
 
 ### `key_type`
 
-The type of key to use for the certificate is 2048-RSA.
+The type of key to use for the certificate can either be `2048-RSA` or `4096-RSA`.
 
 ### `output`
 

--- a/docs/building/air-developer-tool/commands/installApp.md
+++ b/docs/building/air-developer-tool/commands/installApp.md
@@ -20,7 +20,7 @@ adt -installApp
 
 ### `-platform`
 
-The name of the platform of the device. Specify ios or android.
+The name of the platform of the device. Specify ios or android. This is optional, as ADT will determine which platform to connect to using the file extension of the package.
 
 ### `-platformsdk`
 
@@ -48,6 +48,6 @@ adb devices
 
 ### `-package`
 
-The file name of the package to install. On iOS, this must be an IPA file. On Android, this must be an APK package. If the specified package is already installed, ADT returns error code 14:Device error.
+The file name of the package to install. On iOS, this must be an IPA file. On Android, this must be an APK package or an AAB file (which will be converted into an APK using bundletool). If the specified package is already installed, ADT returns error code 14:Device error.
 
 

--- a/docs/building/air-developer-tool/commands/package.md
+++ b/docs/building/air-developer-tool/commands/package.md
@@ -122,10 +122,10 @@ The type of package to create. The supported package types are:
 	- `DEB` — Ubuntu Linux (AIR 2.6 or earlier)
 	- `RPM` — Fedora or OpenSuse Linux (AIR 2.6 or earlier)
 
-- `bundle` — a native desktop aplication bundle. This creates a folder that contains the generated application, in a 'portable' format so that this can be copied, zipped, or turned into an installation packge using platform-specific tools.
-   The applicaiton output depends on the operating system on which the command is run, although the `-arch` option can be used to determine the binary executable format i.e. between 32-bit and 64-bit on Windows, or x64 vs armv8 on Linux.
+- `bundle` — a native desktop application bundle. This creates a folder that contains the generated application, in a 'portable' format so that this can be copied, zipped, or turned into an installation package using platform-specific tools.
+   The application output depends on the operating system on which the command is run, although the `-arch` option can be used to determine the binary executable format i.e. between 32-bit and 64-bit on Windows, or x64 vs armv8 on Linux.
 
-- `cmdline` — a native desktop aplication bundle that does not support a graphical user interface. This is the same as `bundle` but will not create a graphical window, and the application will not contain a stage or display list.
+- `cmdline` — a native desktop application bundle that does not support a graphical user interface. This is the same as `bundle` but will not create a graphical window, and the application will not contain a stage or display list.
 
 
 For more information see [Packaging a desktop native installer](/docs/tutorials/platform/desktop/packaging-native-installer.md).

--- a/docs/building/air-developer-tool/commands/package.md
+++ b/docs/building/air-developer-tool/commands/package.md
@@ -93,11 +93,15 @@ The type of package to create. The supported package types are:
 
 - Android package targets:
 
-	- `apk` — an Android package. A package produced with this target can only be installed on an Android device, not an emulator.
-	- `apk‑captive‑runtime` — an Android package that includes both the application and a captive version of the AIR runtime. A package produced with this target can only be installed on an Android device, not an emulator.
+	- `apk` — an Android package. A package produced with this target can only be installed on an Android device, not an emulator. This also includes a captive version of the runtime and is now the same as using `apk-captive-runtime`.
+	- `apk-captive-runtime` — an Android package that includes both the application and a captive version of the AIR runtime. A package produced with this target can only be installed on an Android device, not an emulator.
 	- `apk-debug` — an Android package with extra debugging information. (The SWF files in the application must also be compiled with debugging support.)
 	- `apk-emulator` — an Android package for use on an emulator without debugging support. (Use the apk-debug target to permit debugging on both emulators and devices.)
-	- `apk-profile` — an Android package that supports application performance and memory profiling.
+	- `apk-profile` — an Android package that supports application performance and memory profiling. This is not supported when using the Gradle-based build system.
+	- `aab` - an Android Application Bundle. This is the format required for uploads to the Play Store and contains the various different native architectures that are supported.
+	- `aab-debug` - an Android Application Bundle with extra debugging information (similar to `apk-debug`).
+	- `android-studio` - generates a folder output that can be opened within Android Studio, which can be useful for debugging or manual adjustments before building an APK or AAB file.
+	- `android-studio-debug` - generates a folder output that can be opened within Android Studio, with the additional debugging support similar to `apk-debug` and `aab-debug`.
 
 - iOS package targets:
 
@@ -110,12 +114,19 @@ The type of package to create. The supported package types are:
 	- `ipa-test-interpreter` — functionally equivalent to a test package, but compiles more quickly. However, the ActionScript bytecode is interpreted and not translated to machine code. As a result, code execution is slower in an interpreter package.
 	- `ipa-test-interpreter-simulator` — functionally equivalent to `ipa-test-interpreter`, but packaged for the iOS simulator. Macintosh-only. If you use this option, you must also include the `-platformsdk` option, specifying the path to the iOS Simulator SDK.
 
-- `native` — a native desktop installer. The type of file produced is the native installation format of the operating system on which the command is run:
+- `native` — a native desktop installer. The type of file produced is the native installation format of the operating system on which the command is run.
+   Note that the installer does not include the AIR runtime, and the latest AIR runtimes cannot be downloaded by the installers from AIR 33 onwards, so this format is strongly discouraged.
 
 	- `EXE` — Windows
 	- `DMG` — Mac
 	- `DEB` — Ubuntu Linux (AIR 2.6 or earlier)
 	- `RPM` — Fedora or OpenSuse Linux (AIR 2.6 or earlier)
+
+- `bundle` — a native desktop aplication bundle. This creates a folder that contains the generated application, in a 'portable' format so that this can be copied, zipped, or turned into an installation packge using platform-specific tools.
+   The applicaiton output depends on the operating system on which the command is run, although the `-arch` option can be used to determine the binary executable format i.e. between 32-bit and 64-bit on Windows, or x64 vs armv8 on Linux.
+
+- `cmdline` — a native desktop aplication bundle that does not support a graphical user interface. This is the same as `bundle` but will not create a graphical window, and the application will not contain a stage or display list.
+
 
 For more information see [Packaging a desktop native installer](/docs/tutorials/platform/desktop/packaging-native-installer.md).
 

--- a/docs/building/air-developer-tool/commands/sign.md
+++ b/docs/building/air-developer-tool/commands/sign.md
@@ -10,16 +10,24 @@ The `-sign` command signs AIRI and ANE files.
 The `-sign` command uses the following syntax:
 
 ```
-adt -sign AIR_SIGNING_OPTIONS input output
+adt -sign AIR_SIGNING_OPTIONS -target type input output
 ```
 
 ### `AIR_SIGNING_OPTIONS`
 
 The AIR signing options identify the certificate used to sign a package file. The signing options are fully described in [ADT code signing options](../option-sets/code-signing-options.md).
 
+### `-target`
+
+This specifies the type of package which is being signed. If omitted, this assumes an AIRI file is provided in order to create an AIR package. Options are:
+- `air`: provide an AIRI file as the input, creating a signed AIR file.
+- `airn`: provide an AIRN file (a generic native installer package).
+- `ane`: provide an ANE file to be signed.
+- `bundle`: provide a MacOS .app bundle folder to be signed via the `codesign` tool (only on MacOS).
+
 ### `input`
 
-The name of the AIRI or ANE file to sign.
+The name of the package to sign.
 
 ### `output` 
 

--- a/docs/building/air-developer-tool/option-sets/file-and-path-options.md
+++ b/docs/building/air-developer-tool/option-sets/file-and-path-options.md
@@ -32,6 +32,10 @@ Places the file or directory into the specified package directory. This option c
 The `<content>` element of the application descriptor file must specify the final location of the main application file within the application package directory tree.
 :::
 
+### `-resdir dir`
+
+The value of `dir` is the name of a directory that contains Android resources that should be included in the target package. This option can be used to quickly include custom resources, see [Custom Resources](../../../tutorials/platform/android/custom-resources).
+
 ### `-extdir dir`
 
 The value of `dir` is the name of a directory to search for native extensions (ANE files). Specify either an absolute path, or a path relative to the current directory. You can specify the `-extdir` option multiple times.


### PR DESCRIPTION
Updating some of the documentation based on changes we've made in the ADT and ADL tools, triggered by github requests:
- github-3443: Updating ADT documentaton for package types plus other errata
- github-3892: Adding '-cmd' description into ADL documentation
