### PR TITLE
Update System Requirements to Java 17 as per Java section.

### DIFF
--- a/docs/basics/install/linux.mdx
+++ b/docs/basics/install/linux.mdx
@@ -16,7 +16,7 @@ To install and run AIR your development environment must meet these minimum requ
 
 - Linux
 - 1.3GB free disk space (for the AIR SDK and does not include other tools)
-- A version of Java 11 JDK
+- A version of Java 17 JDK
 
 
 ## Install the SDK 

--- a/docs/basics/install/macos.mdx
+++ b/docs/basics/install/macos.mdx
@@ -16,7 +16,7 @@ To install and run AIR your development environment must meet these minimum requ
 
 - macOS
 - 1.3GB free disk space (for the AIR SDK and does not include other tools)
-- A version of Java 11 JDK
+- A version of Java 17 JDK
 
 
 ## Install the SDK 

--- a/docs/basics/install/windows.mdx
+++ b/docs/basics/install/windows.mdx
@@ -16,7 +16,7 @@ To install and run AIR your development environment must meet these minimum requ
 
 - Windows 7 or later
 - 1.3GB free disk space (for the AIR SDK and does not include other tools)
-- A version of Java 11 JDK
+- A version of Java 17 JDK
 
 
 ## Install the SDK


### PR DESCRIPTION
In the [Getting Started](https://airsdk.dev/docs/basics/getting-started) section for each OS, the System Requirements specify Java 11 JDK:

<img width="677" height="333" alt="image" src="https://github.com/user-attachments/assets/86db4dd3-2e12-4533-9244-374f4b4fc33a" />

However the Java section at the bottom of the same page recommends Java 17.  This pull request seeks to make this less confusing by bringing the System Requirements in-line with the recommended Java JDK version.

<img width="925" height="152" alt="image" src="https://github.com/user-attachments/assets/576beb8d-1084-43ef-98c6-9f7e00c30901" />
