### PR TITLE
Add a download link to Java 17 JDK

### DIFF
--- a/docs/basics/install/linux.mdx
+++ b/docs/basics/install/linux.mdx
@@ -137,4 +137,4 @@ You must make sure you have the Java Developmet Kit (JDK) installed and that you
 
 We currently recommend using Java 17 but check the release notes for any changes.
 
-
+- [Java SE 17 Archive Downloads](https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html)

--- a/docs/basics/install/macos.mdx
+++ b/docs/basics/install/macos.mdx
@@ -178,3 +178,5 @@ adt -devices -platform android
 You must make sure you have the Java Developmet Kit (JDK) installed and that your `JAVA_HOME` environment variable is set to the JDK's folder. 
 
 We currently recommend using Java 17 but check the release notes for any changes.
+
+- [Java SE 17 Archive Downloads](https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html)

--- a/docs/basics/install/windows.mdx
+++ b/docs/basics/install/windows.mdx
@@ -147,3 +147,5 @@ adt -devices -platform android
 You must make sure you have the Java Developmet Kit (JDK) installed and that your `JAVA_HOME` environment variable is set to the JDK's folder. 
 
 We currently recommend using Java 17 but check the release notes for any changes.
+
+- [Java SE 17 Archive Downloads](https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html)


### PR DESCRIPTION
The correct version of Java, and a way to download it without subscription, is more elusive than it used to be in the past.

The link offered here provides an official page, with direct download links to the last version of Java 17 made available, before the license change imposed a subscription wall.