### PR TITLE
Updating attachCamera/attachNetStream documentation

### DIFF
--- a/static/reference/actionscript/3.0/flash/display3D/textures/VideoTexture.html
+++ b/static/reference/actionscript/3.0/flash/display3D/textures/VideoTexture.html
@@ -408,7 +408,7 @@ showHideInherited();
 <p></p><p>
 	Specifies a video stream from a camera to be rendered within the texture of the VideoTexture object.
 		</p><p>Use this method to attach live video captured by the user to the VideoTexture object. To drop the connection 
-	to the VideoTexture object, set the value of the the Camera parameter to null.</p>
+	to the VideoTexture object, set the value of the theCamera parameter to null.</p>
 	        <p>
         Note that only one <code>VideoTexture</code> object can be linked with a <code>Camera</code>
         object at once. If you call this method with a <code>Camera</code> object that is already
@@ -497,7 +497,7 @@ showHideInherited();
 	        <tr><td><code>bubbles</code></td><td><code>false</code></td></tr>
 		    <tr><td><code>cancelable</code></td><td><code>false</code>; there is no default behavior to cancel.</td></tr>
 	        <tr><td><code>colorSpace</code></td><td>The available color spaces for displaying the video.</td></tr>
-		    <tr><td><code>currentTarget</code></td><td>The object that is actively processing the StageVideoEvent 
+		    <tr><td><code>currentTarget</code></td><td>The object that is actively processing the VideoTextureEvent 
 		object with an event listener.</td></tr>
 		    <tr><td><code>status</code></td><td>Indicates whether the video is being rendered (decoded and displayed) by hardware or software, or not at all.</td></tr>
 		    <tr><td><code>target</code></td><td>The VideoTexture object that changed state.</td></tr>

--- a/static/reference/actionscript/3.0/flash/display3D/textures/VideoTexture.html
+++ b/static/reference/actionscript/3.0/flash/display3D/textures/VideoTexture.html
@@ -300,6 +300,22 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
  [broadcast event] Dispatched when the <span platform="actionscript">Flash Player or</span> AIR application operating
  loses system focus and is becoming inactive.</td><td class="summaryTableOwnerCol"><a href="../../events/EventDispatcher.html">EventDispatcher</a></td>
 </tr>
+<tr class="">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol">
+<div class="summarySignature">
+<a class="signatureLink" href="#event:renderState">renderState</a>
+</div>
+</td><td class="summaryTableDescription summaryTableCol">
+         Dispatched by the VideoTexture object when the render state of the VideoTexture object changes.</td><td class="summaryTableOwnerCol">VideoTexture</td>
+</tr>
+<tr class="">
+<td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol">&nbsp;</td><td class="summaryTableSignatureCol">
+<div class="summarySignature">
+<a class="signatureLink" href="#event:textureReady">textureReady</a>
+</div>
+</td><td class="summaryTableDescription summaryTableCol">
+         Dispatched by the VideoTexture object every time the texture is updated with a new frame.</td><td class="summaryTableOwnerCol">VideoTexture</td>
+</tr>
 </table>
 </div>
 <script type="text/javascript" language="javascript">
@@ -392,8 +408,16 @@ showHideInherited();
 <p></p><p>
 	Specifies a video stream from a camera to be rendered within the texture of the VideoTexture object.
 		</p><p>Use this method to attach live video captured by the user to the VideoTexture object. To drop the connection 
-	to the VideoTexture object, set the value of the theCamera parameter to null.</p>
-	        <span class="label">Parameters</span>
+	to the VideoTexture object, set the value of the the Camera parameter to null.</p>
+	        <p>
+        Note that only one <code>VideoTexture</code> object can be linked with a <code>Camera</code>
+        object at once. If you call this method with a <code>Camera</code> object that is already
+        attached to a different <code>VideoTexture</code> instance, it will be detached from that instance
+        prior to being attached to this instance. This applies to all video consumers i.e. if the
+        <code>Camera</code> object is attached to a <code>StageVideo</code> or <code>Video</code>
+        object, calling this method with the same <code>Camera</code> object will detach that connection.
+        </p>
+                <span class="label">Parameters</span>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20px"></td><td><code><span class="label">theCamera</span>:<a href="../../media/Camera.html">Camera</a></code></td>
@@ -424,7 +448,15 @@ showHideInherited();
 	Specifies a video stream to be rendered within the texture of the VideoTexture object. 
 		</p><p>A video file can be stored on the local file system or on Flash Media Server. 
 	If the value of the netStream argument is null, the video is no longer played in the VideoTexture object.</p>
-	        <span class="label">Parameters</span>
+	        <p>
+        Note that only one <code>VideoTexture</code> object can be linked with a <code>NetStream</code>
+        object at once. If you call this method with a <code>NetStream</code> object that is already
+        attached to a different <code>VideoTexture</code> instance, it will be detached from that instance
+        prior to being attached to this instance. This applies to all video consumers i.e. if the
+        <code>NetStream</code> object is attached to a <code>StageVideo</code> or <code>Video</code>
+        object, calling this method with the same <code>NetStream</code> object will detach that connection.
+        </p>
+                <span class="label">Parameters</span>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20px"></td><td><code><span class="label">netStream</span>:<a href="../../net/NetStream.html">NetStream</a></code></td>
@@ -432,6 +464,88 @@ showHideInherited();
 </table>
 </div>
 <div class="detailSectionHeader">Event detail</div>
+<a name="event:renderState"></a>
+<table cellspacing="0" cellpadding="0" class="detailHeader">
+<tr>
+<td class="detailHeaderName">renderState</td><td class="detailHeaderType">event&nbsp;</td>
+</tr>
+</table>
+<div class="detailBody">
+<span class="label">Event object type: </span><a href="../../events/VideoTextureEvent.html"><code>flash.events.VideoTextureEvent</code></a>
+<br>
+<span class="label">VideoTextureEvent.type property = </span><a href="../../events/VideoTextureEvent.html#RENDER_STATE"><code>flash.events.VideoTextureEvent.RENDER_STATE</code></a>
+<br>
+<p></p>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0                  </td>
+</tr>
+</table>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;17.0
+</td>
+</tr>
+</table>
+<p></p><p>
+         Dispatched by the VideoTexture object when the render state of the VideoTexture object changes.
+                  </p><p>
+		The <code>VideoTextureEvent.RENDER_STATE</code> constant defines the value of the <code>type</code> property of a <code>renderState</code> event object. 
+		</p><p>This event has the following properties:</p>
+		 <table class="innertable" width="100%">
+		    <tr><th>Property</th><th>Value</th></tr>
+	        <tr><td><code>bubbles</code></td><td><code>false</code></td></tr>
+		    <tr><td><code>cancelable</code></td><td><code>false</code>; there is no default behavior to cancel.</td></tr>
+	        <tr><td><code>colorSpace</code></td><td>The available color spaces for displaying the video.</td></tr>
+		    <tr><td><code>currentTarget</code></td><td>The object that is actively processing the StageVideoEvent 
+		object with an event listener.</td></tr>
+		    <tr><td><code>status</code></td><td>Indicates whether the video is being rendered (decoded and displayed) by hardware or software, or not at all.</td></tr>
+		    <tr><td><code>target</code></td><td>The VideoTexture object that changed state.</td></tr>
+		    </table>
+		
+		</div>
+<a name="event:textureReady"></a>
+<table cellspacing="0" cellpadding="0" class="detailHeader">
+<tr>
+<td class="detailHeaderName">textureReady</td><td class="detailHeaderType">event&nbsp;</td><td class="detailHeaderRule">&nbsp;</td>
+</tr>
+</table>
+<div class="detailBody">
+<span class="label">Event object type: </span><a href="../../events/Event.html"><code>flash.events.Event</code></a>
+<br>
+<span class="label">Event.type property = </span><a href="../../events/Event.html#TEXTURE_READY"><code>flash.events.Event.TEXTURE_READY</code></a>
+<br>
+<p></p>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Language version:&nbsp;</b></td><td>ActionScript 3.0                  </td>
+</tr>
+</table>
+<table border="0" cellspacing="0" cellpadding="0">
+<tr>
+<td valign="top" style="white-space:nowrap"><b>Runtime version:&nbsp;</b></td><td>AIR&nbsp;17.0
+</td>
+</tr>
+</table>
+<p></p><p>
+         Dispatched by the VideoTexture object every time the texture is updated with a new frame.
+                  </p><p>
+	</p><p>The <code>Event.TEXTURE_READY</code> constant defines the value of the <code>type</code> property of a <code>textureReady</code> event object.</p>
+	
+	<p>This event is dispatched by Texture, RectangleTexture and CubeTexture objects to signal the completion of an asynchronous upload.  Request an
+	asynchronous upload by using the <code>uploadCompressedTextureFromByteArray()</code> method with a <code>true</code>
+	value for the <code>async</code> argument, or using a method such as <code>uploadFromBitmapDataAsync</code> or
+	<code>uploadFromByteArrayAsync</code>.</p>
+	<p>This event is also dispatched by VideoTexture objects when a new frame has been uploaded into the texture.</p>
+	<p>This event neither bubbles nor is cancelable.</p>
+		<p>This event has the following properties:</p>
+		<table class="innertable" width="100%">
+	    <tr><th>Property</th><th>Value</th></tr>
+	    <tr><td><code>bubbles</code></td><td><code>false</code></td></tr>
+	    <tr><td><code>cancelable</code></td><td><code>false</code>; there is no default behavior to cancel.</td></tr>
+	    <tr><td><code>target</code></td><td>The texture object that dispatched this event.</td></tr>
+	 </table>
+        </div>
 <br>
 <br>
 <hr>
@@ -439,11 +553,10 @@ showHideInherited();
 <p></p>
 <div class="feedbackLink">
 <center>
-<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Wed Sep 28 2022, 6:12 PM GMT+01:00) : flash.display3D.textures.VideoTexture">Submit Feedback</a>
+<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Fri May 1 2026, 9:32 AM GMT+01:00) : flash.display3D.textures.VideoTexture">Submit Feedback</a>
 </center>
 </div>
-<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Wed Sep 28 2022, 6:12 PM GMT+01:00<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
+<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Fri May 1 2026, 9:32 AM GMT+01:00<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
 </div>
 </body>
-</html>
-<!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Wed Sep 28 2022, 6:12 PM GMT+01:00 <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->
+</html><!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Fri May 1 2026, 9:32 AM GMT+01:00 <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->

--- a/static/reference/actionscript/3.0/flash/media/StageVideo.html
+++ b/static/reference/actionscript/3.0/flash/media/StageVideo.html
@@ -814,6 +814,14 @@ showHideInherited();
         
 		<p>Use this method to attach live video captured by the user
 		to the StageVideo object. To drop the connection to the StageVideo object, pass <code>null</code>.</p>
+				<p>
+		Note that only one <code>StageVideo</code> object can be linked with a <code>Camera</code>
+		object at once. If you call this method with a <code>Camera</code> object that is already
+		attached to a different <code>StageVideo</code> instance, it will be detached from that instance
+		prior to being attached to this instance. This applies to all video consumers i.e. if the
+		<code>Camera</code> object is attached to a <code>Video</code> or <code>VideoTexture</code>
+		object, calling this method with the same <code>Camera</code> object will detach that connection.
+		</p>
 				<span class="label">Parameters</span>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
@@ -872,6 +880,14 @@ showHideInherited();
         associated with a video file, use the <code>soundTransform</code> property         
         of the NetStream object that plays the video file.
         </p>        
+                <p>
+        Note that only one <code>StageVideo</code> object can be linked with a <code>NetStream</code>
+        object at once. If you call this method with a <code>NetStream</code> object that is already
+        attached to a different <code>StageVideo</code> instance, it will be detached from that instance
+        prior to being attached to this instance. This applies to all video consumers i.e. if the
+        <code>NetStream</code> object is attached to a <code>Video</code> or <code>VideoTexture</code>
+        object, calling this method with the same <code>NetStream</code> object will detach that connection.
+        </p>
                 <span class="label">Parameters</span>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
@@ -930,11 +946,10 @@ showHideInherited();
 <p></p>
 <div class="feedbackLink">
 <center>
-<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Mon Feb 26 2024, 5:22 PM GMT) : flash.media.StageVideo">Submit Feedback</a>
+<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Fri May 1 2026, 9:32 AM GMT+01:00) : flash.media.StageVideo">Submit Feedback</a>
 </center>
 </div>
-<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Mon Feb 26 2024, 5:22 PM GMT<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
+<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Fri May 1 2026, 9:32 AM GMT+01:00<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
 </div>
 </body>
-</html>
-<!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Mon Feb 26 2024, 5:22 PM GMT <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->
+</html><!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Fri May 1 2026, 9:32 AM GMT+01:00 <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->

--- a/static/reference/actionscript/3.0/flash/media/Video.html
+++ b/static/reference/actionscript/3.0/flash/media/Video.html
@@ -169,38 +169,46 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <tr class="hideInheritedProperty">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol"><img class="inheritedSummaryImage" title="Inherited" alt="Inherited" src="../../images/inheritedSummary.gif"></td><td class="summaryTableSignatureCol"><a class="signatureLink" href="../display/DisplayObject.html#accessibilityProperties">accessibilityProperties</a> : <a href="../accessibility/AccessibilityProperties.html">AccessibilityProperties</a>
 <div class="summaryTableDescription">
+
      The current accessibility options for this display object.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
 <tr class="hideInheritedProperty">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol"><img class="inheritedSummaryImage" title="Inherited" alt="Inherited" src="../../images/inheritedSummary.gif"></td><td class="summaryTableSignatureCol"><a class="signatureLink" href="../display/DisplayObject.html#alpha">alpha</a> : <a href="../../Number.html">Number</a>
 <div class="summaryTableDescription">
+
      Indicates the alpha transparency value of the object specified.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
 <tr class="hideInheritedProperty">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol"><img class="inheritedSummaryImage" title="Inherited" alt="Inherited" src="../../images/inheritedSummary.gif"></td><td class="summaryTableSignatureCol"><a class="signatureLink" href="../display/DisplayObject.html#blendMode">blendMode</a> : <a href="../../String.html">String</a>
 <div class="summaryTableDescription">
+
      A value from the BlendMode class that specifies which blend mode to use.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
 <tr class="hideInheritedProperty">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol"><img class="inheritedSummaryImage" title="Inherited" alt="Inherited" src="../../images/inheritedSummary.gif"></td><td class="summaryTableSignatureCol"><a class="signatureLink" href="../display/DisplayObject.html#blendShader">blendShader</a> : <a href="../display/Shader.html">Shader</a>
 <div class="summaryTableDescription">
+
      Sets a shader that is used for blending the foreground and background.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
 <tr class="hideInheritedProperty">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol"><img class="inheritedSummaryImage" title="Inherited" alt="Inherited" src="../../images/inheritedSummary.gif"></td><td class="summaryTableSignatureCol"><a class="signatureLink" href="../display/DisplayObject.html#cacheAsBitmap">cacheAsBitmap</a> : <a href="../../Boolean.html">Boolean</a>
 <div class="summaryTableDescription">
+
      If set to <code>true</code>, Flash runtimes cache an internal bitmap representation of the
+
      display object.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
 <tr class="hideInheritedProperty">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol"><img class="inheritedSummaryImage" title="Inherited" alt="Inherited" src="../../images/inheritedSummary.gif"></td><td class="summaryTableSignatureCol"><a class="signatureLink" href="../display/DisplayObject.html#cacheAsBitmapMatrix">cacheAsBitmapMatrix</a> : <a href="../geom/Matrix.html">Matrix</a>
 <div class="summaryTableDescription">
+
      If non-null, this Matrix object defines how a display object is rendered when 
+
      <code>cacheAsBitmap</code> is set to <code>true</code>.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
@@ -220,62 +228,74 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <tr class="hideInheritedProperty">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol"><img class="inheritedSummaryImage" title="Inherited" alt="Inherited" src="../../images/inheritedSummary.gif"></td><td class="summaryTableSignatureCol"><a class="signatureLink" href="../display/DisplayObject.html#filters">filters</a> : <a href="../../Array.html">Array</a>
 <div class="summaryTableDescription">
+
      An indexed array that contains each filter object currently associated with the display object.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
 <tr class="hideInheritedProperty">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol"><img class="inheritedSummaryImage" title="Inherited" alt="Inherited" src="../../images/inheritedSummary.gif"></td><td class="summaryTableSignatureCol"><a class="signatureLink" href="../display/DisplayObject.html#height">height</a> : <a href="../../Number.html">Number</a>
 <div class="summaryTableDescription">
+
      Indicates the height of the display object, in pixels.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
 <tr class="hideInheritedProperty">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol"><img class="inheritedSummaryImage" title="Inherited" alt="Inherited" src="../../images/inheritedSummary.gif"></td><td class="summaryTableSignatureCol"><a class="signatureLink" href="../display/DisplayObject.html#loaderInfo">loaderInfo</a> : <a href="../display/LoaderInfo.html">LoaderInfo</a>
 <div class="summaryTableDescription">
+
      Returns a LoaderInfo object containing information about loading the file
+
      to which this display object belongs.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
 <tr class="hideInheritedProperty">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol"><img class="inheritedSummaryImage" title="Inherited" alt="Inherited" src="../../images/inheritedSummary.gif"></td><td class="summaryTableSignatureCol"><a class="signatureLink" href="../display/DisplayObject.html#mask">mask</a> : <a href="../display/DisplayObject.html">DisplayObject</a>
 <div class="summaryTableDescription">
+
      The calling display object is masked by the specified <code>mask</code> object.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
 <tr class="hideInheritedProperty">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol"><img class="inheritedSummaryImage" title="Inherited" alt="Inherited" src="../../images/inheritedSummary.gif"></td><td class="summaryTableSignatureCol"><a class="signatureLink" href="../display/DisplayObject.html#metaData">metaData</a> : <a href="../../Object.html">Object</a>
 <div class="summaryTableDescription">
+
      Obtains the meta data object of the DisplayObject instance if meta data was stored alongside the
+
      the instance of this DisplayObject in the SWF file through a PlaceObject4 tag.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
 <tr class="hideInheritedProperty">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol"><img class="inheritedSummaryImage" title="Inherited" alt="Inherited" src="../../images/inheritedSummary.gif"></td><td class="summaryTableSignatureCol"><a class="signatureLink" href="../display/DisplayObject.html#mouseX">mouseX</a> : <a href="../../Number.html">Number</a>
 <div class="summaryTableDescription">
+
      Indicates the x coordinate of the mouse or user input device position, in pixels.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
 <tr class="hideInheritedProperty">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol"><img class="inheritedSummaryImage" title="Inherited" alt="Inherited" src="../../images/inheritedSummary.gif"></td><td class="summaryTableSignatureCol"><a class="signatureLink" href="../display/DisplayObject.html#mouseY">mouseY</a> : <a href="../../Number.html">Number</a>
 <div class="summaryTableDescription">
+
      Indicates the y coordinate of the mouse or user input device position, in pixels.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
 <tr class="hideInheritedProperty">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol"><img class="inheritedSummaryImage" title="Inherited" alt="Inherited" src="../../images/inheritedSummary.gif"></td><td class="summaryTableSignatureCol"><a class="signatureLink" href="../display/DisplayObject.html#name">name</a> : <a href="../../String.html">String</a>
 <div class="summaryTableDescription">
+
      Indicates the instance name of the DisplayObject.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
 <tr class="hideInheritedProperty">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol"><img class="inheritedSummaryImage" title="Inherited" alt="Inherited" src="../../images/inheritedSummary.gif"></td><td class="summaryTableSignatureCol"><a class="signatureLink" href="../display/DisplayObject.html#opaqueBackground">opaqueBackground</a> : <a href="../../Object.html">Object</a>
 <div class="summaryTableDescription">
+
      Specifies whether the display object is opaque with a certain background color.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
 <tr class="hideInheritedProperty">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol"><img class="inheritedSummaryImage" title="Inherited" alt="Inherited" src="../../images/inheritedSummary.gif"></td><td class="summaryTableSignatureCol"><a class="signatureLink" href="../display/DisplayObject.html#parent">parent</a> : <a href="../display/DisplayObjectContainer.html">DisplayObjectContainer</a>
 <div class="summaryTableDescription">
+
      Indicates the DisplayObjectContainer object that contains this display object.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
@@ -289,61 +309,72 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <tr class="hideInheritedProperty">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol"><img class="inheritedSummaryImage" title="Inherited" alt="Inherited" src="../../images/inheritedSummary.gif"></td><td class="summaryTableSignatureCol"><a class="signatureLink" href="../display/DisplayObject.html#root">root</a> : <a href="../display/DisplayObject.html">DisplayObject</a>
 <div class="summaryTableDescription">
+
      For a display object in a loaded SWF file, the <code>root</code> property is the 
+
      top-most display object in the portion of the display list's tree structure represented by that SWF file.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
 <tr class="hideInheritedProperty">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol"><img class="inheritedSummaryImage" title="Inherited" alt="Inherited" src="../../images/inheritedSummary.gif"></td><td class="summaryTableSignatureCol"><a class="signatureLink" href="../display/DisplayObject.html#rotation">rotation</a> : <a href="../../Number.html">Number</a>
 <div class="summaryTableDescription">
+
      Indicates the rotation of the DisplayObject instance, in degrees, from its original orientation.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
 <tr class="hideInheritedProperty">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol"><img class="inheritedSummaryImage" title="Inherited" alt="Inherited" src="../../images/inheritedSummary.gif"></td><td class="summaryTableSignatureCol"><a class="signatureLink" href="../display/DisplayObject.html#rotationX">rotationX</a> : <a href="../../Number.html">Number</a>
 <div class="summaryTableDescription">
+
      Indicates the x-axis rotation of the DisplayObject instance, in degrees, from its original orientation relative to the 3D parent container.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
 <tr class="hideInheritedProperty">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol"><img class="inheritedSummaryImage" title="Inherited" alt="Inherited" src="../../images/inheritedSummary.gif"></td><td class="summaryTableSignatureCol"><a class="signatureLink" href="../display/DisplayObject.html#rotationY">rotationY</a> : <a href="../../Number.html">Number</a>
 <div class="summaryTableDescription">
+
      Indicates the y-axis rotation of the DisplayObject instance, in degrees, from its original orientation relative to the 3D parent container.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
 <tr class="hideInheritedProperty">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol"><img class="inheritedSummaryImage" title="Inherited" alt="Inherited" src="../../images/inheritedSummary.gif"></td><td class="summaryTableSignatureCol"><a class="signatureLink" href="../display/DisplayObject.html#rotationZ">rotationZ</a> : <a href="../../Number.html">Number</a>
 <div class="summaryTableDescription">
+
      Indicates the z-axis rotation of the DisplayObject instance, in degrees, from its original orientation relative to the 3D parent container.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
 <tr class="hideInheritedProperty">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol"><img class="inheritedSummaryImage" title="Inherited" alt="Inherited" src="../../images/inheritedSummary.gif"></td><td class="summaryTableSignatureCol"><a class="signatureLink" href="../display/DisplayObject.html#scale9Grid">scale9Grid</a> : <a href="../geom/Rectangle.html">Rectangle</a>
 <div class="summaryTableDescription">
+
      The current scaling grid that is in effect.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
 <tr class="hideInheritedProperty">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol"><img class="inheritedSummaryImage" title="Inherited" alt="Inherited" src="../../images/inheritedSummary.gif"></td><td class="summaryTableSignatureCol"><a class="signatureLink" href="../display/DisplayObject.html#scaleX">scaleX</a> : <a href="../../Number.html">Number</a>
 <div class="summaryTableDescription">
+
      Indicates the horizontal scale (percentage) of the object as applied from the registration point.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
 <tr class="hideInheritedProperty">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol"><img class="inheritedSummaryImage" title="Inherited" alt="Inherited" src="../../images/inheritedSummary.gif"></td><td class="summaryTableSignatureCol"><a class="signatureLink" href="../display/DisplayObject.html#scaleY">scaleY</a> : <a href="../../Number.html">Number</a>
 <div class="summaryTableDescription">
+
      Indicates the vertical scale (percentage) of an object as applied from the registration point of the object.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
 <tr class="hideInheritedProperty">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol"><img class="inheritedSummaryImage" title="Inherited" alt="Inherited" src="../../images/inheritedSummary.gif"></td><td class="summaryTableSignatureCol"><a class="signatureLink" href="../display/DisplayObject.html#scaleZ">scaleZ</a> : <a href="../../Number.html">Number</a>
 <div class="summaryTableDescription">
+
      Indicates the depth scale (percentage) of an object as applied from the registration point of the object.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
 <tr class="hideInheritedProperty">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol"><img class="inheritedSummaryImage" title="Inherited" alt="Inherited" src="../../images/inheritedSummary.gif"></td><td class="summaryTableSignatureCol"><a class="signatureLink" href="../display/DisplayObject.html#scrollRect">scrollRect</a> : <a href="../geom/Rectangle.html">Rectangle</a>
 <div class="summaryTableDescription">
+
      The scroll rectangle bounds of the display object.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
@@ -356,12 +387,14 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <tr class="hideInheritedProperty">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol"><img class="inheritedSummaryImage" title="Inherited" alt="Inherited" src="../../images/inheritedSummary.gif"></td><td class="summaryTableSignatureCol"><a class="signatureLink" href="../display/DisplayObject.html#stage">stage</a> : <a href="../display/Stage.html">Stage</a>
 <div class="summaryTableDescription">
+
      The Stage of the display object.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
 <tr class="hideInheritedProperty">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol"><img class="inheritedSummaryImage" title="Inherited" alt="Inherited" src="../../images/inheritedSummary.gif"></td><td class="summaryTableSignatureCol"><a class="signatureLink" href="../display/DisplayObject.html#transform">transform</a> : <a href="../geom/Transform.html">Transform</a>
 <div class="summaryTableDescription">
+
     An object with properties pertaining to a display object's matrix, color transform, and pixel bounds.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
@@ -380,33 +413,41 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <tr class="hideInheritedProperty">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol"><img class="inheritedSummaryImage" title="Inherited" alt="Inherited" src="../../images/inheritedSummary.gif"></td><td class="summaryTableSignatureCol"><a class="signatureLink" href="../display/DisplayObject.html#visible">visible</a> : <a href="../../Boolean.html">Boolean</a>
 <div class="summaryTableDescription">
+
      Whether or not the display object is visible.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
 <tr class="hideInheritedProperty">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol"><img class="inheritedSummaryImage" title="Inherited" alt="Inherited" src="../../images/inheritedSummary.gif"></td><td class="summaryTableSignatureCol"><a class="signatureLink" href="../display/DisplayObject.html#width">width</a> : <a href="../../Number.html">Number</a>
 <div class="summaryTableDescription">
+
      Indicates the width of the display object, in pixels.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
 <tr class="hideInheritedProperty">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol"><img class="inheritedSummaryImage" title="Inherited" alt="Inherited" src="../../images/inheritedSummary.gif"></td><td class="summaryTableSignatureCol"><a class="signatureLink" href="../display/DisplayObject.html#x">x</a> : <a href="../../Number.html">Number</a>
 <div class="summaryTableDescription">
+
      Indicates the <i>x</i> coordinate of the DisplayObject instance relative to the local coordinates of
+
      the parent DisplayObjectContainer.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
 <tr class="hideInheritedProperty">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol"><img class="inheritedSummaryImage" title="Inherited" alt="Inherited" src="../../images/inheritedSummary.gif"></td><td class="summaryTableSignatureCol"><a class="signatureLink" href="../display/DisplayObject.html#y">y</a> : <a href="../../Number.html">Number</a>
 <div class="summaryTableDescription">
+
      Indicates the <i>y</i> coordinate of the DisplayObject instance relative to the local coordinates of
+
      the parent DisplayObjectContainer.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
 <tr class="hideInheritedProperty">
 <td class="summaryTablePaddingCol">&nbsp;</td><td class="summaryTableInheritanceCol"><img class="inheritedSummaryImage" title="Inherited" alt="Inherited" src="../../images/inheritedSummary.gif"></td><td class="summaryTableSignatureCol"><a class="signatureLink" href="../display/DisplayObject.html#z">z</a> : <a href="../../Number.html">Number</a>
 <div class="summaryTableDescription">
+
      Indicates the z coordinate position along the z-axis of the DisplayObject
+
      instance relative to the 3D parent container.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
@@ -489,7 +530,9 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="../display/DisplayObject.html#getBounds()">getBounds</a>(targetCoordinateSpace:<a href="../display/DisplayObject.html">DisplayObject</a>):<a href="../geom/Rectangle.html">Rectangle</a>
 </div>
 <div class="summaryTableDescription">
+
      Returns a rectangle that defines the area of the display object relative to the coordinate system
+
      of the <code>targetCoordinateSpace</code> object.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
@@ -499,8 +542,11 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="../display/DisplayObject.html#getRect()">getRect</a>(targetCoordinateSpace:<a href="../display/DisplayObject.html">DisplayObject</a>):<a href="../geom/Rectangle.html">Rectangle</a>
 </div>
 <div class="summaryTableDescription">
+
     Returns a rectangle that defines the boundary of the display object, 
+
     based on the coordinate system defined by the <code>targetCoordinateSpace</code> 
+
     parameter, excluding any strokes on shapes.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
@@ -510,7 +556,9 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="../display/DisplayObject.html#globalToLocal()">globalToLocal</a>(point:<a href="../geom/Point.html">Point</a>):<a href="../geom/Point.html">Point</a>
 </div>
 <div class="summaryTableDescription">
+
      Converts the <code>point</code> object from the Stage (global) coordinates
+
      to the display object's (local) coordinates.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
@@ -520,7 +568,9 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="../display/DisplayObject.html#globalToLocal3D()">globalToLocal3D</a>(point:<a href="../geom/Point.html">Point</a>):<a href="../geom/Vector3D.html">Vector3D</a>
 </div>
 <div class="summaryTableDescription">
+
      Converts a two-dimensional point from the Stage (global) coordinates to a
+
      three-dimensional display object's (local) coordinates.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
@@ -550,7 +600,9 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="../display/DisplayObject.html#hitTestObject()">hitTestObject</a>(obj:<a href="../display/DisplayObject.html">DisplayObject</a>):<a href="../../Boolean.html">Boolean</a>
 </div>
 <div class="summaryTableDescription">
+
      Evaluates the bounding box of the display object to see if it overlaps or intersects with the
+
      bounding box of the <code>obj</code> display object.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
@@ -560,7 +612,9 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="../display/DisplayObject.html#hitTestPoint()">hitTestPoint</a>(x:<a href="../../Number.html">Number</a>, y:<a href="../../Number.html">Number</a>, shapeFlag:<a href="../../Boolean.html">Boolean</a> = false):<a href="../../Boolean.html">Boolean</a>
 </div>
 <div class="summaryTableDescription">
+
      Evaluates the display object to see if it overlaps or intersects with the
+
      point specified by the <code>x</code> and <code>y</code> parameters.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
@@ -582,7 +636,9 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="../display/DisplayObject.html#local3DToGlobal()">local3DToGlobal</a>(point3d:<a href="../geom/Vector3D.html">Vector3D</a>):<a href="../geom/Point.html">Point</a>
 </div>
 <div class="summaryTableDescription">
+
      Converts a three-dimensional point of the three-dimensional display 
+
      object's (local) coordinates to a two-dimensional point in the Stage (global) coordinates.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
@@ -592,7 +648,9 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="../display/DisplayObject.html#localToGlobal()">localToGlobal</a>(point:<a href="../geom/Point.html">Point</a>):<a href="../geom/Point.html">Point</a>
 </div>
 <div class="summaryTableDescription">
+
      Converts the <code>point</code> object from the display object's (local) coordinates to the
+
      Stage (global) coordinates.</div>
 </td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
@@ -697,6 +755,7 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="../display/DisplayObject.html#event:added">added</a>
 </div>
 </td><td class="summaryTableDescription summaryTableCol">
+
  Dispatched when a display object is added to the display list.</td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
 <tr class="hideInheritedEvent">
@@ -705,7 +764,9 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="../display/DisplayObject.html#event:addedToStage">addedToStage</a>
 </div>
 </td><td class="summaryTableDescription summaryTableCol">
+
  Dispatched when a display object is added to the on stage display list, 
+
  either directly or through the addition of a sub tree in which the display object is contained.</td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
 <tr class="hideInheritedEvent">
@@ -723,7 +784,9 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="../display/DisplayObject.html#event:enterFrame">enterFrame</a>
 </div>
 </td><td class="summaryTableDescription summaryTableCol">
+
  [broadcast event] Dispatched when the playhead is entering a new 
+
  frame.</td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
 <tr class="hideInheritedEvent">
@@ -732,6 +795,7 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="../display/DisplayObject.html#event:exitFrame">exitFrame</a>
 </div>
 </td><td class="summaryTableDescription summaryTableCol">
+
  [broadcast event] Dispatched when the playhead is exiting the current frame.</td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
 <tr class="hideInheritedEvent">
@@ -740,6 +804,7 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="../display/DisplayObject.html#event:frameConstructed">frameConstructed</a>
 </div>
 </td><td class="summaryTableDescription summaryTableCol">
+
  [broadcast event] Dispatched after the constructors of frame display objects have run but before frame scripts have run.</td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
 <tr class="hideInheritedEvent">
@@ -748,6 +813,7 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="../display/DisplayObject.html#event:removed">removed</a>
 </div>
 </td><td class="summaryTableDescription summaryTableCol">
+
  Dispatched when a display object is about to be removed from the display list.</td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
 <tr class="hideInheritedEvent">
@@ -756,7 +822,9 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="../display/DisplayObject.html#event:removedFromStage">removedFromStage</a>
 </div>
 </td><td class="summaryTableDescription summaryTableCol">
+
  Dispatched when a display object is about to be removed from the display list, 
+
  either directly or through the removal of a sub tree in which the display object is contained.</td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
 <tr class="hideInheritedEvent">
@@ -765,6 +833,7 @@ if (!isEclipse() || window.name != ECLIPSE_FRAME_NAME) {titleBar_setSubTitle("Cl
 <a class="signatureLink" href="../display/DisplayObject.html#event:render">render</a>
 </div>
 </td><td class="summaryTableDescription summaryTableCol">
+
  [broadcast event] Dispatched when the display list is about to be updated and rendered.</td><td class="summaryTableOwnerCol"><a href="../display/DisplayObject.html">DisplayObject</a></td>
 </tr>
 </table>
@@ -1045,7 +1114,15 @@ function asyncErrorHandler(event:AsyncErrorEvent):void
      	 <p><b>Note:</b> In an iOS AIR application, camera video cannot be displayed when the application
 	 uses GPU rendering mode.</p>
 	 
-     <span class="label">Parameters</span>
+     <p>
+     Note that only one <code>Video</code> object can be linked with a <code>Camera</code>
+     object at once. If you call this method with a <code>Camera</code> object that is already
+     attached to a different <code>Video</code> instance, it will be detached from that instance
+     prior to being attached to this instance. This applies to all video consumers i.e. if the
+     <code>Camera</code> object is attached to a <code>StageVideo</code> or <code>VideoTexture</code>
+     object, calling this method with the same <code>Camera</code> object will detach that connection.
+     </p>
+          <span class="label">Parameters</span>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
 <td width="20px"></td><td><code><span class="label">camera</span>:<a href="Camera.html">Camera</a></code> &mdash; A Camera object that is capturing video data. 
@@ -1063,7 +1140,8 @@ function asyncErrorHandler(event:AsyncErrorEvent):void
 </div>
 <br>
 <span class="label">Example</span>
-<br><p></p>
+<br>
+<p></p>
 </div>
 <a name="attachNetStream()"></a>
 <table cellspacing="0" cellpadding="0" class="detailHeader">
@@ -1100,6 +1178,14 @@ function asyncErrorHandler(event:AsyncErrorEvent):void
      associated with a video file, use the <code>soundTransform</code> property 
      of the NetStream object that plays the video file.
      </p>
+          <p>
+     Note that only one <code>Video</code> object can be linked with a <code>NetStream</code>
+     object at once. If you call this method with a <code>NetStream</code> object that is already
+     attached to a different <code>Video</code> instance, it will be detached from that instance
+     prior to being attached to this instance. This applies to all video consumers i.e. if the
+     <code>NetStream</code> object is attached to a <code>StageVideo</code> or <code>VideoTexture</code>
+     object, calling this method with the same <code>NetStream</code> object will detach that connection.
+     </p>
           <span class="label">Parameters</span>
 <table border="0" cellspacing="0" cellpadding="0">
 <tr>
@@ -1122,7 +1208,8 @@ function asyncErrorHandler(event:AsyncErrorEvent):void
 </div>
 <br>
 <span class="label">Example</span>
-<br><p></p>
+<br>
+<p></p>
 </div>
 <a name="clear()"></a>
 <table cellspacing="0" cellpadding="0" class="detailHeader">
@@ -1231,11 +1318,10 @@ function asyncErrorHandler(event:AsyncErrorEvent):void
 <p></p>
 <div class="feedbackLink">
 <center>
-<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Wed Sep 28 2022, 6:12 PM GMT+01:00) : flash.media.Video">Submit Feedback</a>
+<a href="mailto:adobe.support@harman.com?subject=ASLR Feedback(Fri May 1 2026, 9:32 AM GMT+01:00) : flash.media.Video">Submit Feedback</a>
 </center>
 </div>
-<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Wed Sep 28 2022, 6:12 PM GMT+01:00<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
+<center class="copyright"> &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. <br>Fri May 1 2026, 9:32 AM GMT+01:00<br> <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  </center>
 </div>
 </body>
-</html>
-<!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Wed Sep 28 2022, 6:12 PM GMT+01:00 <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->
+</html><!-- &copy; 2004-2022 Adobe Systems Incorporated. All rights reserved. Fri May 1 2026, 9:32 AM GMT+01:00 <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/80x15.png" /></a>  -->


### PR DESCRIPTION
For Video, StageVideo and VideoTexture classes. Adding notes to clarify that only one video object can be attached to a Camera/NetStream object at once. See https://github.com/Gamua/Starling-Framework/issues/1124